### PR TITLE
[REFACTOR] 2th auth setting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Auto detect text files and perform LF normalization
+* text=auto eol=lf
+
+# Explicitly declare text files
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.mjs text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+
+# SVG can be text or binary - treat as text for consistency
+*.svg text eol=lf

--- a/omechu-app/package.json
+++ b/omechu-app/package.json
@@ -62,5 +62,5 @@
       "prettier --write"
     ]
   },
-  "packageManager": "pnpm@10.20.0"
+  "packageManager": "pnpm@10.24.0"
 }

--- a/omechu-app/src/app_FSD/(auth)/callback/page.tsx
+++ b/omechu-app/src/app_FSD/(auth)/callback/page.tsx
@@ -3,8 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { useAuthStore } from "@/entities_FSD/user/model/auth.store";
-import { getCurrentUser } from "@/entities_FSD/user/api/authApi";
+import { useAuthStore, getCurrentUser } from "@/entities_FSD/user";
 import Toast from "@/components/common/Toast";
 
 export default function AuthCallbackPage() {

--- a/omechu-app/src/app_FSD/(auth)/forgot-password/page.tsx
+++ b/omechu-app/src/app_FSD/(auth)/forgot-password/page.tsx
@@ -5,11 +5,12 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 import Toast from "@/components/common/Toast";
-import type { FindPasswordFormValues } from "@/entities_FSD/user/model/auth.schema";
-import { useRequestPasswordResetMutation } from "@/entities_FSD/user/lib/hooks/useAuth";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
-
-import ForgotPasswordForm from "@/widgets_FSD/auth/forgot-password-form/ui/ForgotPasswordForm";
+import {
+  useRequestPasswordResetMutation,
+  ApiClientError,
+  type FindPasswordFormValues,
+} from "@/entities_FSD/user";
+import { ForgotPasswordForm } from "@/widgets_FSD/auth/forgot-password-form";
 
 export default function FindPasswordPage() {
   const [showToast, setShowToast] = useState(false);

--- a/omechu-app/src/app_FSD/(auth)/forgot-password/sent/page.tsx
+++ b/omechu-app/src/app_FSD/(auth)/forgot-password/sent/page.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import EmailSentMessage from "./components/EmailSentMessage";
+import { EmailSentMessage } from "../../../../widgets_FSD/auth/email-sent-message";
 
 export default function FindPasswordEmailSentPage() {
   return (

--- a/omechu-app/src/app_FSD/(auth)/reset-password/page.tsx
+++ b/omechu-app/src/app_FSD/(auth)/reset-password/page.tsx
@@ -5,13 +5,14 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import AlertModal from "@/components/common/AlertModal";
 import ModalWrapper from "@/components/common/ModalWrapper";
-import type { ResetPasswordFormValues } from "@/entities_FSD/user/model/auth.schema";
-import { useResetPasswordMutation } from "@/entities_FSD/user/lib/hooks/useAuth";
+import {
+  useResetPasswordMutation,
+  ApiClientError,
+  type ResetPasswordFormValues,
+} from "@/entities_FSD/user";
 import Toast from "@/components/common/Toast";
-
-import ResetPasswordForm from "@/widgets_FSD/auth/reset-password-form/ui/ResetPasswordForm";
+import { ResetPasswordForm } from "@/widgets_FSD/auth/reset-password-form";
 import Header from "@/components/common/Header";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
 
 export default function ResetPasswordPage() {
   return (

--- a/omechu-app/src/app_FSD/(auth)/sign-up/api/agreements.ts
+++ b/omechu-app/src/app_FSD/(auth)/sign-up/api/agreements.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import axiosInstance from "@/lib/api/axios";
-import type { ApiResponse } from "@/entities_FSD/user/api/authApi";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
+import { ApiClientError, type ApiResponse } from "@/entities_FSD/user";
 
 export interface AgreementConsentBody {
   agreeAll: boolean;

--- a/omechu-app/src/app_FSD/(auth)/sign-up/page.tsx
+++ b/omechu-app/src/app_FSD/(auth)/sign-up/page.tsx
@@ -12,16 +12,13 @@ import Toast from "@/components/common/Toast";
 import { TERMS_CONFIG } from "@/components/settings/terms.config";
 import {
   signupSchema,
-  type SignupFormValues,
-} from "@/entities_FSD/user/model/auth.schema";
-import {
   useSignupMutation,
   useLoginMutation,
-} from "@/entities_FSD/user/lib/hooks/useAuth";
-import { useAuthStore } from "@/entities_FSD/user/model/auth.store";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
-
-import SignUpForm from "@/widgets_FSD/auth/sign-up-form/ui/SignUpForm";
+  useAuthStore,
+  ApiClientError,
+  type SignupFormValues,
+} from "@/entities_FSD/user";
+import { SignUpForm } from "@/widgets_FSD/auth/sign-up-form";
 import TermsModal from "@/widgets_FSD/auth/sign-up-form/ui/TermsModal";
 
 type ModalType = "service" | "privacy" | "location";

--- a/omechu-app/src/entities_FSD/user/index.ts
+++ b/omechu-app/src/entities_FSD/user/index.ts
@@ -1,0 +1,49 @@
+// API
+export {
+  login,
+  signup,
+  logout,
+  sendVerificationCode,
+  verifyVerificationCode,
+  requestPasswordReset,
+  resetPassword,
+  changePassword,
+  getCurrentUser,
+  ApiClientError,
+} from "./api/authApi";
+export { fetchProfile } from "./api/profileApi";
+export type { ApiResponse, ApiError } from "./api/authApi";
+
+// Hooks
+export {
+  useLoginMutation,
+  useSignupMutation,
+  useLogoutMutation,
+  useSendVerificationCodeMutation,
+  useVerifyVerificationCodeMutation,
+  useRequestPasswordResetMutation,
+  useResetPasswordMutation,
+  useUserQuery,
+} from "./lib/hooks/useAuth";
+export { useProfile } from "./lib/hooks/useProfile";
+
+// Store
+export { useAuthStore } from "./model/auth.store";
+
+// Schemas
+export {
+  loginSchema,
+  signupSchema,
+  findPasswordSchema,
+  resetPasswordSchema,
+} from "./model/auth.schema";
+
+// Types
+export type {
+  LoginFormValues,
+  SignupFormValues,
+  FindPasswordFormValues,
+  ResetPasswordFormValues,
+} from "./model/auth.schema";
+export type { ProfileType, UpdateProfileBody } from "./model/profile.types";
+export type { LoginTokens, LoginSuccessData } from "./api/authApi";

--- a/omechu-app/src/widgets_FSD/account-settings/index.ts
+++ b/omechu-app/src/widgets_FSD/account-settings/index.ts
@@ -1,0 +1,1 @@
+export { default as AccountSettingsClient } from "./ui/AccountSettingsClient";

--- a/omechu-app/src/widgets_FSD/account-settings/ui/AccountSettingsClient.tsx
+++ b/omechu-app/src/widgets_FSD/account-settings/ui/AccountSettingsClient.tsx
@@ -4,9 +4,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import { useProfile } from "@/entities_FSD/user/lib/hooks/useProfile";
-import { logout } from "@/entities_FSD/user/api/authApi";
-import { useAuthStore } from "@/entities_FSD/user/model/auth.store";
+import { useProfile, logout, useAuthStore } from "@/entities_FSD/user";
 
 import AlertModal from "@/components/common/AlertModal";
 import Header from "@/components/common/Header";

--- a/omechu-app/src/widgets_FSD/auth/email-sent-message/index.ts
+++ b/omechu-app/src/widgets_FSD/auth/email-sent-message/index.ts
@@ -1,0 +1,1 @@
+export { EmailSentMessage } from "./ui/EmailSentMessage";

--- a/omechu-app/src/widgets_FSD/auth/email-sent-message/ui/EmailSentMessage.tsx
+++ b/omechu-app/src/widgets_FSD/auth/email-sent-message/ui/EmailSentMessage.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 import RoundButton from "@/components/common/button/RoundButton";
 
-export default function EmailSentMessage() {
+export function EmailSentMessage() {
   return (
     <div className="flex w-full max-w-sm flex-col items-center gap-10 text-center">
       <div className="flex flex-col gap-3">

--- a/omechu-app/src/widgets_FSD/auth/forgot-password-form/index.ts
+++ b/omechu-app/src/widgets_FSD/auth/forgot-password-form/index.ts
@@ -1,0 +1,1 @@
+export { default as ForgotPasswordForm } from "./ui/ForgotPasswordForm";

--- a/omechu-app/src/widgets_FSD/auth/forgot-password-form/ui/ForgotPasswordForm.tsx
+++ b/omechu-app/src/widgets_FSD/auth/forgot-password-form/ui/ForgotPasswordForm.tsx
@@ -10,7 +10,7 @@ import Input from "@/components/common/Input";
 import {
   findPasswordSchema,
   type FindPasswordFormValues,
-} from "@/entities_FSD/user/model/auth.schema";
+} from "@/entities_FSD/user";
 
 type ForgotPasswordFormProps = {
   onFormSubmit: (data: FindPasswordFormValues) => Promise<void>;

--- a/omechu-app/src/widgets_FSD/auth/reset-password-form/index.ts
+++ b/omechu-app/src/widgets_FSD/auth/reset-password-form/index.ts
@@ -1,0 +1,1 @@
+export { default as ResetPasswordForm } from "./ui/ResetPasswordForm";

--- a/omechu-app/src/widgets_FSD/auth/reset-password-form/ui/ResetPasswordForm.tsx
+++ b/omechu-app/src/widgets_FSD/auth/reset-password-form/ui/ResetPasswordForm.tsx
@@ -6,12 +6,12 @@ import { useForm, Controller } from "react-hook-form";
 import Input from "@/components/common/Input";
 import {
   resetPasswordSchema,
+  ApiClientError,
   type ResetPasswordFormValues,
-} from "@/entities_FSD/user/model/auth.schema";
+} from "@/entities_FSD/user";
 import Toast from "@/components/common/Toast";
 import { useState } from "react";
 import SquareButton from "@/components/common/button/SquareButton";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
 
 type ResetPasswordFormProps = {
   onFormSubmit: (data: ResetPasswordFormValues) => Promise<void>;

--- a/omechu-app/src/widgets_FSD/auth/sign-in-form/index.ts
+++ b/omechu-app/src/widgets_FSD/auth/sign-in-form/index.ts
@@ -1,0 +1,1 @@
+export { default as SignInForm } from "./ui/SignInForm";

--- a/omechu-app/src/widgets_FSD/auth/sign-in-form/ui/SignInForm.tsx
+++ b/omechu-app/src/widgets_FSD/auth/sign-in-form/ui/SignInForm.tsx
@@ -5,8 +5,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { fetchProfile } from "@/entities_FSD/user/api/profileApi";
-
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, Controller } from "react-hook-form";
 
@@ -14,13 +12,14 @@ import Checkbox from "@/components/common/Checkbox";
 import SquareButton from "@/components/common/button/SquareButton";
 import Input from "@/components/common/Input";
 import Toast from "@/components/common/Toast";
-import { useAuthStore } from "@/entities_FSD/user/model/auth.store";
 import {
+  fetchProfile,
+  useAuthStore,
   loginSchema,
-  LoginFormValues,
-} from "@/entities_FSD/user/model/auth.schema";
-import { useLoginMutation } from "@/entities_FSD/user/lib/hooks/useAuth";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
+  useLoginMutation,
+  ApiClientError,
+  type LoginFormValues,
+} from "@/entities_FSD/user";
 
 export default function SignInForm() {
   const [showToast, setShowToast] = useState(false);

--- a/omechu-app/src/widgets_FSD/auth/sign-up-form/index.ts
+++ b/omechu-app/src/widgets_FSD/auth/sign-up-form/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpForm } from "./ui/SignUpForm";

--- a/omechu-app/src/widgets_FSD/auth/sign-up-form/ui/TermsAgreement.tsx
+++ b/omechu-app/src/widgets_FSD/auth/sign-up-form/ui/TermsAgreement.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { useFormContext } from "react-hook-form";
 
 import Checkbox from "@/components/common/Checkbox";
-import type { SignupFormValues } from "@/entities_FSD/user/model/auth.schema";
+import type { SignupFormValues } from "@/entities_FSD/user";
 
 type ModalType = "service" | "privacy" | "location";
 

--- a/omechu-app/src/widgets_FSD/auth/sign-up-form/ui/UserInfoFields.tsx
+++ b/omechu-app/src/widgets_FSD/auth/sign-up-form/ui/UserInfoFields.tsx
@@ -7,10 +7,10 @@ import Input from "@/components/common/Input";
 import {
   useSendVerificationCodeMutation,
   useVerifyVerificationCodeMutation,
-} from "@/entities_FSD/user/lib/hooks/useAuth";
-import type { SignupFormValues } from "@/entities_FSD/user/model/auth.schema";
+  ApiClientError,
+  type SignupFormValues,
+} from "@/entities_FSD/user";
 import Toast from "@/components/common/Toast";
-import { ApiClientError } from "@/entities_FSD/user/api/authApi";
 
 export default function UserInfoFields() {
   const {

--- a/omechu-app/src/widgets_FSD/change-password/index.ts
+++ b/omechu-app/src/widgets_FSD/change-password/index.ts
@@ -1,0 +1,1 @@
+export { default as ChangePasswordClient } from "./ui/ChangePasswordClient";

--- a/omechu-app/src/widgets_FSD/change-password/ui/ChangePasswordClient.tsx
+++ b/omechu-app/src/widgets_FSD/change-password/ui/ChangePasswordClient.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import { changePassword } from "@/entities_FSD/user/api/authApi";
+import { changePassword } from "@/entities_FSD/user";
 import AlertModal from "@/components/common/AlertModal";
 import Header from "@/components/common/Header";
 import Input from "@/components/common/Input";

--- a/omechu-app/src/widgets_FSD/settings-menu/index.ts
+++ b/omechu-app/src/widgets_FSD/settings-menu/index.ts
@@ -1,0 +1,1 @@
+export { default as SettingsClient } from "./ui/SettingsClient";


### PR DESCRIPTION
## 🔀 Pull Request Title
간결하고 명확한 제목 작성 (예: `feat: 로그인 기능 구현`)
- Closes #203 

<br>

## 📌 PR 설명
이번 PR에서 어떤 작업을 했는지 요약해주세요.
- [ ] 
- [ ] 
- [ ] 

<br>

## 📷 스크린샷
UI 변경이 있을 경우 스크린샷을 첨부해주세요.

<br>

## ✅ FSD Architecture Checklist
Feature-Sliced Design 원칙을 준수했는지 확인해주세요.

### 레이어 규칙
- [ ] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [ ] 동일 레이어 간 import가 없음
- [ ] 순환 의존성이 없음

### 네이밍 컨벤션
- [ ] 파일명이 정해진 패턴을 따름 (*.ui.tsx, *.hook.ts, *.api.ts 등)
- [ ] 폴더명이 kebab-case로 작성됨
- [ ] 배럴 익스포트(index.ts)를 사용함

### Import 경로
- [ ] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [ ] 상대 경로 사용 최소화

## 🔍 추가 설명
리뷰어가 알아야 할 추가 정보나 요청사항이 있다면 적어주세요.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor to FSD barrel imports and auth flows**
> 
> - Introduces `entities_FSD/user/index.ts` re-exporting APIs, hooks, schemas, and types; updates auth pages/widgets to import from this barrel
> - Adds widget barrel files for auth forms/components (`sign-in`, `sign-up`, `forgot-password`, `reset-password`, `email-sent-message`) and converts `EmailSentMessage` to a named export
> - Adds/updates settings widgets: `account-settings` (profile display, logout) and `change-password` (validation, success modal)
> - Tweaks auth pages: callback, forgot/reset password, sign-up/sign-in now use barrel imports, consistent toasts, and profile prefetch on login
> - Adds `.gitattributes` for EOL normalization and bumps `packageManager` to `pnpm@10.24.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fbe4d18008cbcfc270fdf7cd6897bb6ffe634f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->