### PR TITLE
[FIX] 공용 컴포넌트(Button, Input) 스타일 버그 수정

### DIFF
--- a/omechu-app/src/app/globals.css
+++ b/omechu-app/src/app/globals.css
@@ -298,3 +298,12 @@ input[type="search"]::-webkit-search-cancel-button {
 .react-datepicker__day--outside-month {
   @apply text-gray-400!;
 } */
+
+/* Autofill 스타일 초기화 */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 30px white inset !important;
+  -webkit-text-fill-color: var(--color-font-high) !important;
+}

--- a/omechu-app/src/shared/ui/button/BattleButton.tsx
+++ b/omechu-app/src/shared/ui/button/BattleButton.tsx
@@ -48,13 +48,14 @@ export const BattleButton = ({
   fontColor,
   bgColor,
   width,
+  className,
   children,
   ...props
 }: BattleButtonProps) => {
   return (
     <button
       type="button"
-      className={battleButtonStyles({ fontColor, bgColor, width })}
+      className={clsx(battleButtonStyles({ fontColor, bgColor, width }), className)}
       {...props}
     >
       {children}

--- a/omechu-app/src/shared/ui/button/BottomButton.tsx
+++ b/omechu-app/src/shared/ui/button/BottomButton.tsx
@@ -40,13 +40,14 @@ type BottomButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
 
 export const BottomButton = ({
   variant,
+  className,
   children,
   ...props
 }: BottomButtonProps) => {
   return (
     <button
       type="button"
-      className={bottomButtonStyles({ variant })}
+      className={clsx(bottomButtonStyles({ variant }), className)}
       {...props}
     >
       {children}

--- a/omechu-app/src/shared/ui/button/Button.tsx
+++ b/omechu-app/src/shared/ui/button/Button.tsx
@@ -51,13 +51,14 @@ export const Button = ({
   fontColor,
   bgColor,
   width,
+  className,
   children,
   ...props
 }: ButtonProps) => {
   return (
     <button
       type="button"
-      className={buttonStyles({ fontColor, bgColor, width })}
+      className={clsx(buttonStyles({ fontColor, bgColor, width }), className)}
       {...props}
     >
       {children}

--- a/omechu-app/src/shared/ui/input/Input.tsx
+++ b/omechu-app/src/shared/ui/input/Input.tsx
@@ -125,31 +125,32 @@ SearchInput.displayName = "SearchInput";
 
 export const Input = React.forwardRef<HTMLInputElement, BaseInputProps>(
   (props, ref) => {
-    const { type = "text", ...rest } = props;
+    const { type = "text", className, width, height, rounded, disabled, ...rest } = props;
     if (type === "password") {
-      return <PasswordInput ref={ref} {...rest} />;
+      return <PasswordInput ref={ref} className={className} width={width} height={height} rounded={rounded} disabled={disabled} {...rest} />;
     }
     if (type === "search") {
-      return <SearchInput ref={ref} {...rest} />;
+      return <SearchInput ref={ref} className={className} width={width} height={height} rounded={rounded} disabled={disabled} {...rest} />;
     }
     return (
-      <input
-        ref={ref}
-        type={type === "number" ? "number" : type}
-        disabled={props.disabled}
-        autoComplete="off"
-        value={props.value}
-        onChange={props.onChange}
+      <div
         className={clsx(
-          inputStyles({
-            width: props.width,
-            height: props.height,
-            rounded: props.rounded,
-          }),
-          props.className,
+          "relative",
+          inputStyles({ width, height, rounded }),
+          className,
         )}
-        {...rest}
-      />
+      >
+        <input
+          ref={ref}
+          type={type === "number" ? "number" : type}
+          disabled={disabled}
+          autoComplete="off"
+          value={props.value}
+          onChange={props.onChange}
+          className="w-full flex-1 bg-transparent outline-none"
+          {...rest}
+        />
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Summary
- Button 컴포넌트의 className이 CVA 스타일을 덮어쓰는 버그 수정
- Input 컴포넌트의 모든 타입에 일관된 wrapper div 구조 적용
- 브라우저 autofill 시 배경색이 변경되는 문제 해결

## Changes
### `Button.tsx`
- `className` prop을 분리하여 `clsx`로 CVA 스타일과 병합

### `Input.tsx`  
- `type="text"` 등 일반 input도 password/search와 동일한 div wrapper 구조로 변경
- 스타일링 일관성 확보

### `globals.css`
- `-webkit-autofill` 스타일 초기화 추가
- autofill 시 흰색 배경 유지

## Test Plan
- [ ] Button에 `className` prop 전달 시 기존 스타일이 유지되는지 확인
- [ ] Input의 text, password, search 타입이 동일한 스타일로 렌더링되는지 확인
- [ ] 브라우저 autofill 후 Input 배경색이 흰색으로 유지되는지 확인

closes #228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent input rendering and fixes Button style merging, plus normalizes autofill appearance.
> 
> - `Input.tsx`: All input types now render within a wrapper `div` using `inputStyles`; forwards `className`, `width`, `height`, `rounded`, `disabled` to `PasswordInput`/`SearchInput`; adds consistent inner `input` classes.
> - `Button.tsx`: Adds `className` prop and merges with `buttonStyles` via `clsx` to prevent style override.
> - `globals.css`: Adds `-webkit-autofill` reset to preserve white background and set text color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f71193680c38a2567373a705dbf716d6b6c933a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->