### PR TITLE
[FEAT] 인증 페이지 UI 개선 2차

### DIFF
--- a/omechu-app/public/auth/checked-round.svg
+++ b/omechu-app/public/auth/checked-round.svg
@@ -1,4 +1,4 @@
-<svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="8.5" cy="8.5" r="8" fill="#00A3FF" stroke="#626262"/>
-<path d="M6.96875 12.25L3.40625 8.6875L4.29688 7.79688L6.96875 10.4688L12.7031 4.73438L13.5938 5.625L6.96875 12.25Z" fill="white"/>
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9" cy="9" r="8.5" fill="#FF7676" stroke="#242424"/>
+<path d="M7.3785 12.9118L3.60645 9.13976L4.54946 8.19675L7.3785 11.0258L13.4502 4.9541L14.3932 5.89712L7.3785 12.9118Z" fill="white"/>
 </svg>

--- a/omechu-app/public/auth/unchecked-round.svg
+++ b/omechu-app/public/auth/unchecked-round.svg
@@ -1,3 +1,4 @@
-<svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="8.5" cy="8.5" r="8" stroke="#626262"/>
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9" cy="9" r="8.75" fill="#242424" fill-opacity="0.08" stroke="#242424" stroke-width="0.5"/>
+<path d="M7.75 12.9118L3.97795 9.13976L4.92096 8.19675L7.75 11.0258L13.8217 4.9541L14.7647 5.89712L7.75 12.9118Z" fill="white"/>
 </svg>

--- a/omechu-app/src/app/(auth)/forgot-password/page.tsx
+++ b/omechu-app/src/app/(auth)/forgot-password/page.tsx
@@ -4,9 +4,11 @@ import { useState } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { ApiClientError } from "@/entities/user/api/authApi";
-import { useRequestPasswordResetMutation } from "@/entities/user/lib/hooks/useAuth";
-import type { FindPasswordFormValues } from "@/entities/user/model/auth.schema";
+import {
+  ApiClientError,
+  useRequestPasswordResetMutation,
+  type FindPasswordFormValues,
+} from "@/entities/user";
 import { Header, Toast } from "@/shared";
 import { ForgotPasswordForm } from "@/widgets/auth";
 
@@ -35,15 +37,19 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <main className="flex flex-1 flex-col">
+    <div className="flex flex-1 flex-col">
       <Header onLeftClick={() => router.back()} />
 
       <div className="flex flex-col px-5">
         {/* 타이틀 영역 */}
-        <div className="flex flex-col items-center gap-3 py-5">
+        <div className="flex flex-col items-center p-12">
           <h1 className="text-body-2-bold text-font-high text-center">
             비밀번호 찾기
           </h1>
+        </div>
+
+        {/* 설명 영역 */}
+        <div className="flex items-center justify-center px-5 py-2.5">
           <p className="text-body-4-regular text-font-low text-center">
             가입하신 이메일 주소를 입력하여
             <br />
@@ -52,12 +58,12 @@ export default function ForgotPasswordPage() {
         </div>
 
         {/* 폼 영역 */}
-        <div className="pt-8">
+        <div className="pt-12">
           <ForgotPasswordForm onFormSubmit={handleFormSubmit} />
         </div>
       </div>
 
       <Toast message={toastMessage} show={showToast} className="bottom-20" />
-    </main>
+    </div>
   );
 }

--- a/omechu-app/src/app/(auth)/forgot-password/sent/page.tsx
+++ b/omechu-app/src/app/(auth)/forgot-password/sent/page.tsx
@@ -1,20 +1,9 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-
-import { Header } from "@/shared";
 import { EmailSentMessage } from "@/widgets/auth";
 
 export default function PasswordResetEmailSentPage() {
-  const router = useRouter();
-
   return (
-    <main className="flex flex-1 flex-col">
-      <Header onLeftClick={() => router.back()} />
-
-      <div className="flex flex-1 flex-col items-center justify-center">
-        <EmailSentMessage />
-      </div>
-    </main>
+    <div className="flex flex-1 flex-col items-center justify-center px-4">
+      <EmailSentMessage />
+    </div>
   );
 }

--- a/omechu-app/src/app/(auth)/layout.tsx
+++ b/omechu-app/src/app/(auth)/layout.tsx
@@ -1,0 +1,16 @@
+/**
+ * 인증 관련 페이지 공통 레이아웃
+ * - 기본 컨테이너만 제공
+ * - Header, 로고는 각 하위 레이아웃에서 처리
+ */
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-1 flex-col">
+      {children}
+    </div>
+  );
+}

--- a/omechu-app/src/app/(auth)/sign-in/email/page.tsx
+++ b/omechu-app/src/app/(auth)/sign-in/email/page.tsx
@@ -17,16 +17,18 @@ import {
   LoginFormValues,
 } from "@/entities/user/model/auth.schema";
 import { useAuthStore } from "@/entities/user/model/auth.store";
-import { Button, FormField, Input, Toast, Header } from "@/shared";
+import { Button, FormField, Input, Toast } from "@/shared";
 
 /**
  * 이메일 로그인 페이지
  * - 이메일/비밀번호 입력 폼
- * - 비밀번호 찾기 링크
+ * - 로그인 상태 유지 체크박스
+ * - 비밀번호 찾기 / 회원가입 링크
  */
 export default function EmailSignInPage() {
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
+  const [rememberMe, setRememberMe] = useState(true);
   const toastTimerRef = useRef<number | null>(null);
   const navigatedRef = useRef(false);
   const justLoggedInRef = useRef(false);
@@ -156,75 +158,103 @@ export default function EmailSignInPage() {
   const handleFormSubmit = handleSubmit(onSubmit);
 
   return (
-    <main className="flex flex-1 flex-col">
-      <Header onLeftClick={() => router.back()} />
+    <div className="flex w-full flex-col items-center">
+      {/* 로그인 폼 */}
+      <form onSubmit={handleFormSubmit} className="mt-14 flex w-full flex-col gap-5 px-5">
+        {/* 입력 필드 + 체크박스 + 버튼 영역 */}
+        <div className="flex flex-col gap-3">
+          {/* 입력 필드들 */}
+          <div className="flex flex-col gap-2.5">
+            {/* 이메일 */}
+            <Controller
+              name="email"
+              control={control}
+              render={({ field }) => (
+                <FormField
+                  label="이메일"
+                  id="email"
+                  helperText={errors.email?.message}
+                  helperState={errors.email ? "error" : undefined}
+                >
+                  <Input
+                    type="email"
+                    placeholder="이메일을 입력해주세요"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    className="w-full"
+                  />
+                </FormField>
+              )}
+            />
 
-      <form onSubmit={handleFormSubmit} className="flex flex-1 flex-col gap-6 px-5">
-        <Controller
-          name="email"
-          control={control}
-          render={({ field }) => (
-            <FormField
-              label="이메일"
-              id="email"
-              helperText={errors.email?.message}
-              helperState={errors.email ? "error" : undefined}
-            >
-              <Input
-                type="email"
-                placeholder="abc@omechu.com"
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-                width="default"
-                className="w-full"
-              />
-            </FormField>
-          )}
-        />
+            {/* 비밀번호 */}
+            <Controller
+              name="password"
+              control={control}
+              render={({ field }) => (
+                <FormField
+                  label="비밀번호"
+                  id="password"
+                  helperText={errors.password?.message || "* 대소문자, 숫자 및 특수문자 포함 8자 이상"}
+                  helperState={errors.password ? "error" : undefined}
+                >
+                  <Input
+                    type="password"
+                    placeholder="비밀번호를 입력해주세요"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    className="w-full"
+                  />
+                </FormField>
+              )}
+            />
 
-        <Controller
-          name="password"
-          control={control}
-          render={({ field }) => (
-            <FormField
-              label="비밀번호"
-              id="password"
-              helperText={errors.password?.message || "* 대소문자, 숫자 및 특수문자 포함 8자 이상"}
-              helperState={errors.password ? "error" : undefined}
-            >
-              <Input
-                type="password"
-                placeholder="비밀번호 입력"
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-                width="default"
-                className="w-full"
-              />
-            </FormField>
-          )}
-        />
+            {/* 로그인 상태 유지 체크박스 */}
+            <label className="flex cursor-pointer items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setRememberMe(!rememberMe)}
+                className="flex size-5 items-center justify-center rounded-sm border-[0.5px] border-font-high bg-background-secondary"
+              >
+                {rememberMe && (
+                  <svg width="12" height="10" viewBox="0 0 12 10" fill="none">
+                    <path
+                      d="M1 5L4.5 8.5L11 1"
+                      stroke="#242424"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+              </button>
+              <span className="text-caption-1-regular text-font-high">
+                로그인 상태 유지
+              </span>
+            </label>
+          </div>
 
-        <div className="flex-1" />
-
-        <div className="pb-6">
-          <Button type="submit" disabled={isPending} className="w-full">
+          {/* 로그인 버튼 */}
+          <Button type="submit" disabled={isPending} className="h-12 w-full">
             {isPending ? "로그인 중..." : "로그인"}
           </Button>
+        </div>
 
-          <div className="mt-4 flex justify-center">
-            <Link
-              href="/forgot-password"
-              className="text-body-4-regular text-font-medium hover:underline"
-            >
-              비밀번호를 잊으셨나요?
-            </Link>
-          </div>
+        {/* 비밀번호 찾기 / 회원가입 링크 */}
+        <div className="flex items-center justify-center gap-1 text-caption-1-regular">
+          <Link href="/forgot-password" className="text-font-medium">
+            비밀번호 찾기
+          </Link>
+          <span className="text-font-placeholder">|</span>
+          <Link href="/sign-up" className="text-font-medium">
+            회원가입
+          </Link>
         </div>
       </form>
 
       <Toast message={toastMessage} show={showToast} className="bottom-20" />
-    </main>
+    </div>
   );
 }

--- a/omechu-app/src/app/(auth)/sign-in/layout.tsx
+++ b/omechu-app/src/app/(auth)/sign-in/layout.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+import { Header } from "@/shared/ui/Header";
+
+/**
+ * 로그인 관련 페이지 레이아웃
+ * - 뒤로가기 헤더
+ * - 로고 고정 위치
+ * - 컨텐츠 중앙 정렬
+ */
+export default function SignInLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+
+  return (
+    <>
+      <Header onLeftClick={() => router.back()} />
+
+      {/* 로고 - 고정 위치 */}
+      <div className="mt-12 flex justify-center">
+        <Image
+          src="/logo/logo.png"
+          alt="Omechu Logo"
+          width={139}
+          height={92}
+          priority
+        />
+      </div>
+
+      {/* 컨텐츠 영역 */}
+      <div className="flex flex-1 flex-col items-center">
+        {children}
+      </div>
+    </>
+  );
+}

--- a/omechu-app/src/app/(auth)/sign-in/page.tsx
+++ b/omechu-app/src/app/(auth)/sign-in/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 
 import { AuthButton } from "@/shared";
@@ -6,27 +5,25 @@ import { AuthButton } from "@/shared";
 /**
  * 소셜 로그인 메인 페이지
  * - 카카오, 구글 소셜 로그인 버튼
- * - 이메일 로그인 링크
+ * - 이메일 로그인/회원가입 링크
  */
 export default function SignInPage() {
   return (
-    <main className="flex flex-1 flex-col">
-      {/* 상단 로고 영역 */}
-      <div className="flex flex-1 flex-col items-center justify-center">
-        <Image
-          src="/logo/logo.png"
-          alt="Omechu Logo"
-          width={139}
-          height={92}
-          priority
-        />
-        <p className="text-body-4-regular text-font-medium mt-4">
-          3초만에 간편 로그인
-        </p>
-      </div>
+    <div className="flex flex-col items-center">
+      {/* 로그인 버튼 영역 */}
+      <div className="mt-20 flex w-80 flex-col gap-6">
+        {/* 카카오 로그인 */}
+        <a href={`${process.env.NEXT_PUBLIC_API_URL}/auth/kakao`}>
+          <AuthButton
+            variant="kakao"
+            icon="/kakao/kakao.svg"
+            iconAlt="카카오 아이콘"
+            type="button"
+          >
+            카카오 로그인
+          </AuthButton>
+        </a>
 
-      {/* 하단 로그인 버튼 영역 */}
-      <div className="flex flex-col gap-3 px-5 pb-10">
         {/* 구글 로그인 */}
         <a href={`${process.env.NEXT_PUBLIC_API_URL}/auth/google`}>
           <AuthButton
@@ -38,33 +35,18 @@ export default function SignInPage() {
             구글로 로그인
           </AuthButton>
         </a>
-
-        {/* 카카오 로그인 */}
-        <a href={`${process.env.NEXT_PUBLIC_API_URL}/auth/kakao`}>
-          <AuthButton
-            variant="kakao"
-            icon="/kakao/kakao.svg"
-            iconAlt="카카오 아이콘"
-            type="button"
-          >
-            카카오로 로그인
-          </AuthButton>
-        </a>
-
-        {/* 이메일 로그인 / 회원가입 링크 */}
-        <div className="text-body-4-regular mt-4 flex items-center justify-center gap-2">
-          <Link
-            href="/sign-in/email"
-            className="text-font-medium hover:underline"
-          >
-            이메일로 로그인
-          </Link>
-          <span className="text-font-placeholder">|</span>
-          <Link href="/sign-up" className="text-font-medium hover:underline">
-            회원가입
-          </Link>
-        </div>
       </div>
-    </main>
+
+      {/* 이메일 로그인 / 회원가입 링크 */}
+      <div className="mt-10 flex items-center gap-3 text-caption-1-regular">
+        <Link href="/sign-in/email" className="text-font-medium hover:underline">
+          이메일 로그인
+        </Link>
+        <span className="text-caption-2-medium text-font-placeholder">ㅣ</span>
+        <Link href="/sign-up" className="text-font-medium hover:underline">
+          이메일 회원가입
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/omechu-app/src/app/(auth)/sign-up/page.tsx
+++ b/omechu-app/src/app/(auth)/sign-up/page.tsx
@@ -7,34 +7,22 @@ import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { ApiClientError } from "@/entities/user/api/authApi";
 import {
+  ApiClientError,
   useSignupMutation,
   useLoginMutation,
-} from "@/entities/user/lib/hooks/useAuth";
-import {
   signupSchema,
   type SignupFormValues,
-} from "@/entities/user/model/auth.schema";
-import { useAuthStore } from "@/entities/user/model/auth.store";
-import { BottomButton, ModalWrapper, Toast, TERMS_CONFIG } from "@/shared";
-import { SignUpForm, TermsModal } from "@/widgets/auth";
-
-type ModalType = "service" | "privacy" | "location";
-
-/** 모달 타입과 약관 설정 매핑 */
-const MODAL_TO_TERMS_TYPE = {
-  service: "service",
-  privacy: "personal-info",
-  location: "location-info",
-} as const;
-
-/** 모달 타입과 폼 필드 매핑 */
-const MODAL_TO_FORM_FIELD = {
-  service: "termsService",
-  privacy: "termsPrivacy",
-  location: "termsLocation",
-} as const;
+  useAuthStore,
+} from "@/entities/user";
+import { BottomButton, Header, ModalWrapper, Toast, TERMS_CONFIG } from "@/shared";
+import {
+  SignUpForm,
+  TermsModal,
+  type ModalType,
+  MODAL_TO_TERMS_TYPE,
+  MODAL_TO_FORM_FIELD,
+} from "@/widgets/auth";
 
 export default function SignUpPage() {
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
@@ -109,16 +97,19 @@ export default function SignUpPage() {
 
   return (
     <FormProvider {...methods}>
-      <div className="flex min-h-screen flex-col">
+      <div className="flex flex-col">
+        {/* 헤더 */}
+        <Header onLeftClick={() => router.back()} />
+
         {/* 제목 */}
-        <header className="px-5 pt-20 pb-8 text-center">
+        <div className="px-5 py-5 text-center">
           <h1 className="text-body-2-bold text-font-high">
             회원 정보를 입력해 주세요
           </h1>
-        </header>
+        </div>
 
         {/* 폼 영역 */}
-        <main className="flex-1 overflow-y-auto px-5 pb-[70px]">
+        <main className="flex-1 px-5 pb-16">
           <SignUpForm
             setActiveModal={setActiveModal}
             onSubmit={handleSubmit(onSubmit)}
@@ -126,15 +117,14 @@ export default function SignUpPage() {
         </main>
 
         {/* 하단 버튼 */}
-        <footer className="fixed bottom-0 left-0 right-0 mx-auto w-full max-w-[430px]">
-          <BottomButton
-            type="submit"
-            form="signup-form"
-            disabled={!isValid || isSigningUp}
-          >
-            {isSigningUp ? "가입하는 중..." : "가입하기"}
-          </BottomButton>
-        </footer>
+        <BottomButton
+          type="submit"
+          form="signup-form"
+          disabled={!isValid || isSigningUp}
+          className="mx-auto max-w-[430px]"
+        >
+          {isSigningUp ? "가입하는 중..." : "가입하기"}
+        </BottomButton>
 
         {/* 약관 모달 */}
         {activeModal && (

--- a/omechu-app/src/shared/ui/box/CheckBox.tsx
+++ b/omechu-app/src/shared/ui/box/CheckBox.tsx
@@ -11,9 +11,14 @@ type CheckboxProps = {
 
 export const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(
   ({ label, id, variant = "square", ...props }, ref) => {
+    const size = variant === "round" ? 18 : 17;
+
     return (
       <label htmlFor={id} className="flex cursor-pointer items-center">
-        <div className="relative h-[17px] w-[17px]">
+        <div
+          className="relative shrink-0"
+          style={{ width: size, height: size }}
+        >
           <input
             type="checkbox"
             id={id}
@@ -28,16 +33,16 @@ export const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(
               <Image
                 src="/auth/unchecked-round.svg"
                 alt="unchecked"
-                width={17}
-                height={17}
+                width={18}
+                height={18}
                 className="peer-checked:hidden"
               />
               {/* Round Checked */}
               <Image
                 src="/auth/checked-round.svg"
                 alt="checked"
-                width={17}
-                height={17}
+                width={18}
+                height={18}
                 className="hidden peer-checked:block"
               />
             </>

--- a/omechu-app/src/widgets/auth/email-sent-message/ui/EmailSentMessage.tsx
+++ b/omechu-app/src/widgets/auth/email-sent-message/ui/EmailSentMessage.tsx
@@ -1,17 +1,15 @@
-"use client";
-
 import Link from "next/link";
 
 import { Button } from "@/shared";
 
 export default function EmailSentMessage() {
   return (
-    <div className="flex w-full flex-col items-center gap-10 px-5 text-center">
-      <div className="flex flex-col gap-3">
+    <div className="flex w-full flex-col items-center gap-8 text-center">
+      <div className="flex flex-col">
         <h1 className="text-body-2-bold text-font-high">
           비밀번호 재설정 메일을 발송했어요
         </h1>
-        <p className="text-body-4-regular text-font-low">
+        <p className="text-body-4-regular text-font-low mt-2">
           보내드린 메일을 확인하신 후,
           <br />
           비밀번호를 다시 설정해 주세요
@@ -20,7 +18,7 @@ export default function EmailSentMessage() {
 
       <Link href="/sign-in" className="w-full">
         <Button type="button" className="w-full">
-          로그인 하기
+          로그인하기
         </Button>
       </Link>
     </div>

--- a/omechu-app/src/widgets/auth/index.ts
+++ b/omechu-app/src/widgets/auth/index.ts
@@ -2,4 +2,11 @@ export { EmailSentMessage } from "./email-sent-message";
 export { ForgotPasswordForm } from "./forgot-password-form";
 export { ResetPasswordForm } from "./reset-password-form";
 export { SignInForm } from "./sign-in-form";
-export { SignUpForm, TermsModal, UserInfoFields } from "./sign-up-form";
+export {
+  SignUpForm,
+  TermsModal,
+  UserInfoFields,
+  type ModalType,
+  MODAL_TO_TERMS_TYPE,
+  MODAL_TO_FORM_FIELD,
+} from "./sign-up-form";

--- a/omechu-app/src/widgets/auth/sign-up-form/index.ts
+++ b/omechu-app/src/widgets/auth/sign-up-form/index.ts
@@ -1,3 +1,8 @@
+// UI Components
 export { default as SignUpForm } from "./ui/SignUpForm";
 export { default as TermsModal } from "./ui/TermsModal";
 export { default as UserInfoFields } from "./ui/UserInfoFields";
+
+// Types & Constants
+export type { ModalType } from "./types";
+export { MODAL_TO_TERMS_TYPE, MODAL_TO_FORM_FIELD } from "./types";

--- a/omechu-app/src/widgets/auth/sign-up-form/types.ts
+++ b/omechu-app/src/widgets/auth/sign-up-form/types.ts
@@ -1,0 +1,34 @@
+import type { SignupFormValues } from "@/entities/user";
+import type { TermsType } from "@/shared";
+
+/**
+ * 회원가입 약관 모달 타입
+ * - service: 서비스 이용약관
+ * - privacy: 개인정보 처리방침
+ * - location: 위치기반 서비스 이용약관
+ */
+export type ModalType = "service" | "privacy" | "location";
+
+/**
+ * ModalType → TermsType (TERMS_CONFIG 키) 매핑
+ */
+export const MODAL_TO_TERMS_TYPE: Record<ModalType, TermsType> = {
+  service: "service",
+  privacy: "personal-info",
+  location: "location-info",
+} as const;
+
+/**
+ * ModalType → SignupFormValues 필드명 매핑
+ */
+export const MODAL_TO_FORM_FIELD: Record<
+  ModalType,
+  keyof Pick<
+    SignupFormValues,
+    "termsService" | "termsPrivacy" | "termsLocation"
+  >
+> = {
+  service: "termsService",
+  privacy: "termsPrivacy",
+  location: "termsLocation",
+} as const;

--- a/omechu-app/src/widgets/auth/sign-up-form/ui/SignUpForm.tsx
+++ b/omechu-app/src/widgets/auth/sign-up-form/ui/SignUpForm.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import type { ModalType } from "../types";
 import TermsAgreement from "./TermsAgreement";
 import UserInfoFields from "./UserInfoFields";
-
-type ModalType = "service" | "privacy" | "location";
 
 type SignUpFormProps = {
   setActiveModal: (modal: ModalType | null) => void;

--- a/omechu-app/src/widgets/auth/sign-up-form/ui/TermsAgreement.tsx
+++ b/omechu-app/src/widgets/auth/sign-up-form/ui/TermsAgreement.tsx
@@ -4,10 +4,10 @@ import React from "react";
 
 import { useFormContext } from "react-hook-form";
 
-import type { SignupFormValues } from "@/entities/user/model/auth.schema";
+import type { SignupFormValues } from "@/entities/user";
 import { CheckBox } from "@/shared";
 
-type ModalType = "service" | "privacy" | "location";
+import type { ModalType } from "../types";
 
 type TermsAgreementProps = {
   setActiveModal: (modal: ModalType | null) => void;

--- a/omechu-app/src/widgets/auth/sign-up-form/ui/UserInfoFields.tsx
+++ b/omechu-app/src/widgets/auth/sign-up-form/ui/UserInfoFields.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 
 import { Controller, useFormContext } from "react-hook-form";
 
-import { ApiClientError } from "@/entities/user/api/authApi";
 import {
+  ApiClientError,
   useSendVerificationCodeMutation,
   useVerifyVerificationCodeMutation,
-} from "@/entities/user/lib/hooks/useAuth";
-import type { SignupFormValues } from "@/entities/user/model/auth.schema";
+  type SignupFormValues,
+} from "@/entities/user";
 import { Button, FormField, Input, Toast } from "@/shared";
 
 export default function UserInfoFields() {
@@ -102,17 +102,7 @@ export default function UserInfoFields() {
             id="signup-email"
             helperText={errors.email?.message}
             helperState={errors.email ? "error" : undefined}
-          >
-            <div className="flex items-center gap-2.5">
-              <Input
-                type="email"
-                placeholder="이메일을 입력해주세요"
-                value={field.value || ""}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-                width="sm"
-                className="flex-1"
-              />
+            rightSlot={
               <Button
                 type="button"
                 onClick={handleSendCode}
@@ -125,7 +115,16 @@ export default function UserInfoFields() {
                     ? "재전송"
                     : "인증번호 전송"}
               </Button>
-            </div>
+            }
+          >
+            <Input
+              type="email"
+              placeholder="이메일을 입력해주세요"
+              value={field.value || ""}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              className="flex-1!"
+            />
           </FormField>
         )}
       />
@@ -141,17 +140,7 @@ export default function UserInfoFields() {
               id="signup-verification-code"
               helperText={errors.verificationCode?.message}
               helperState={errors.verificationCode ? "error" : undefined}
-            >
-              <div className="flex items-center gap-2.5">
-                <Input
-                  type="password"
-                  placeholder="인증번호 6자리를 입력해주세요"
-                  value={field.value || ""}
-                  onChange={field.onChange}
-                  onBlur={field.onBlur}
-                  width="sm"
-                  className="flex-1"
-                />
+              rightSlot={
                 <Button
                   type="button"
                   onClick={handleVerifyCode}
@@ -169,7 +158,16 @@ export default function UserInfoFields() {
                       ? "인증 완료"
                       : "인증번호 확인"}
                 </Button>
-              </div>
+              }
+            >
+              <Input
+                type="password"
+                placeholder="인증번호 6자리를 입력해주세요"
+                value={field.value || ""}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                className="flex-1!"
+              />
             </FormField>
           )}
         />
@@ -198,6 +196,7 @@ export default function UserInfoFields() {
                 setPasswordBlurred(true);
                 field.onBlur();
               }}
+              className="w-full!"
             />
           </FormField>
         )}
@@ -229,6 +228,7 @@ export default function UserInfoFields() {
                 setPasswordConfirmBlurred(true);
                 field.onBlur();
               }}
+              className="w-full!"
             />
           </FormField>
         )}


### PR DESCRIPTION
## Summary

- 체크박스 아이콘 디자인 변경 및 컴포넌트 사이즈 분리
- auth 페이지 공통 레이아웃 추가 (sign-in 전용 레이아웃 포함)
- 회원가입 폼 구조 개선 (타입 분리, export 정리)
- auth 페이지들 UI 스타일 개선 및 일관성 확보

## Changes

### 체크박스
- round 체크박스 SVG: 17px → 18px, 색상 변경
- CheckBox 컴포넌트: variant별 사이즈 분리

### 레이아웃
- `(auth)/layout.tsx`: 인증 페이지 기본 컨테이너
- `sign-in/layout.tsx`: 로그인 페이지 전용 (헤더, 로고)

### 회원가입 폼
- `types.ts` 분리하여 ModalType, 매핑 상수 정의
- export 구조 정리

### 페이지 UI
- sign-in, sign-up, forgot-password 페이지 스타일 개선

## Related Issue

Closes #231

## Test plan

- [ ] 회원가입 페이지 체크박스 동작 확인
- [ ] 로그인 페이지 레이아웃 확인
- [ ] 비밀번호 찾기 페이지 UI 확인
- [ ] 모바일 뷰 레이아웃 확인