### PR TITLE
[FIX] sign-up 페이지 TERMS_CONFIG import 오류 수정

### DIFF
--- a/omechu-app/src/app/(auth)/sign-up/page.tsx
+++ b/omechu-app/src/app/(auth)/sign-up/page.tsx
@@ -15,13 +15,17 @@ import {
   type SignupFormValues,
   useAuthStore,
 } from "@/entities/user";
+import { BottomButton, Header, ModalWrapper, Toast } from "@/shared";
 import {
-  BottomButton,
-  Header,
-  ModalWrapper,
-  Toast,
-  TERMS_CONFIG,
-} from "@/shared";
+  termsForServiceMain,
+  termsForServiceServe,
+  termsForPersonalInfoMain,
+  termsForPersonalInfoServe,
+  termsForLocationServiceMain,
+  termsForLocationServiceServe,
+  type TermsConfig,
+  type TermsType,
+} from "@/shared/constants/terms";
 import {
   SignUpForm,
   TermsModal,
@@ -29,6 +33,21 @@ import {
   MODAL_TO_TERMS_TYPE,
   MODAL_TO_FORM_FIELD,
 } from "@/widgets/auth";
+
+const TERMS_CONFIG: Record<TermsType, TermsConfig> = {
+  service: {
+    title: "서비스 이용약관",
+    data: [...termsForServiceMain, ...termsForServiceServe],
+  },
+  "personal-info": {
+    title: "개인정보 처리방침",
+    data: [...termsForPersonalInfoMain, ...termsForPersonalInfoServe],
+  },
+  "location-info": {
+    title: "위치기반 서비스 이용약관",
+    data: [...termsForLocationServiceMain, ...termsForLocationServiceServe],
+  },
+};
 
 export default function SignUpPage() {
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);


### PR DESCRIPTION
- Closes #247

---

## 📌 PR 설명

PR #243에서 `terms.config.ts` 삭제 후 `sign-up/page.tsx`에서 `TERMS_CONFIG` import 오류 수정

- [x] `sign-up/page.tsx`에서 약관 데이터 직접 import 방식으로 변경
- [x] `shared/constants/terms/data/`에서 직접 데이터 가져오도록 수정
- [x] 로컬에서 `TERMS_CONFIG` 객체 구성

---

## 📷 스크린샷

UI 변경 없음

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

`@/shared`에서 `TERMS_CONFIG`를 export하는 대신, `sign-up/page.tsx`에서 직접 데이터 파일들을 import하여 로컬에서 config 객체를 구성하는 방식으로 변경했습니다.