### PR TITLE
[FIX] useProfile.ts FSD import 경로 수정

### DIFF
--- a/omechu-app/src/entities/user/lib/hooks/useProfile.ts
+++ b/omechu-app/src/entities/user/lib/hooks/useProfile.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { fetchProfile } from "@/entities/mypage/api/profile";
+import { fetchProfile } from "@/entities/user/api/profileApi";
 import { ProfileType } from "@/entities/user/model/profile.types";
 
 // userId는 number 타입으로 사용합니다.


### PR DESCRIPTION
## PR Title Format

> **[FIX] useProfile.ts FSD import 경로 수정 (#258)**

- Closes #258

---

## 📌 PR 설명

이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] `entities/mypage` 삭제로 인해 깨진 import 경로 수정
- [x] `@/entities/mypage/api/profile` → `@/entities/user/api/profileApi`

---

## 📷 스크린샷

UI 변경 없음

---

## ✅ FSD Architecture Checklist

Feature-Sliced Design 원칙을 준수했는지 확인해주세요.

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

- `entities/mypage` 모듈 삭제 후 남아있던 깨진 import 경로 수정