### PR TITLE
[REFACTOR] Figma 디자인 토큰과 globals.css 네이밍 일치

### DIFF
--- a/omechu-app/src/app/(omechu)/mypage/(settings)/alarm-setting/page.tsx
+++ b/omechu-app/src/app/(omechu)/mypage/(settings)/alarm-setting/page.tsx
@@ -85,7 +85,7 @@ export default function AlarmSettingPage() {
               }}
             />
           </div>
-          <div className="text-caption-1-regular text-font-extralow">
+          <div className="text-caption-1-regular text-font-extra-low">
             매일 식사 시간마다 메뉴를 결정해 드려요.
           </div>
           {mealAlarms.map((alarm) => (
@@ -111,7 +111,7 @@ export default function AlarmSettingPage() {
                   className={
                     isAlarmFeatureEnabled && alarm.enabled
                       ? "text-brand-primary"
-                      : "text-font-extralow"
+                      : "text-font-extra-low"
                   }
                 >
                   {isAlarmFeatureEnabled && alarm.enabled ? alarm.time : "OFF"}

--- a/omechu-app/src/app/(omechu)/mypage/(settings)/email-inquiry/page.tsx
+++ b/omechu-app/src/app/(omechu)/mypage/(settings)/email-inquiry/page.tsx
@@ -57,7 +57,7 @@ export default function EmailInquiryPage() {
           접수하기
         </Button>
 
-        <section className="text-font-extralow bg-brand-tertiary flex h-20 w-83.5 items-center justify-center rounded-[10px] text-sm font-medium whitespace-pre-line">
+        <section className="text-font-extra-low bg-brand-tertiary flex h-20 w-83.5 items-center justify-center rounded-[10px] text-sm font-medium whitespace-pre-line">
           {`접수하신 문의는 운영자 메일로 전송됩니다. \n 순차적으로 확인 후 최대한 빠르게 이메일로 \n 답장드리겠습니다.`}
         </section>
       </main>

--- a/omechu-app/src/app/(omechu)/mypage/(settings)/email-inquiry/page.tsx
+++ b/omechu-app/src/app/(omechu)/mypage/(settings)/email-inquiry/page.tsx
@@ -57,7 +57,7 @@ export default function EmailInquiryPage() {
           접수하기
         </Button>
 
-        <section className="text-font-extra-low bg-brand-tertiary flex h-20 w-83.5 items-center justify-center rounded-[10px] text-sm font-medium whitespace-pre-line">
+        <section className="text-font-extra-low bg-brand-tertiary text-caption-1-medium flex h-20 w-83.5 items-center justify-center rounded-[10px] whitespace-pre-line">
           {`접수하신 문의는 운영자 메일로 전송됩니다. \n 순차적으로 확인 후 최대한 빠르게 이메일로 \n 답장드리겠습니다.`}
         </section>
       </main>

--- a/omechu-app/src/app/(omechu)/mypage/mukburim-log/page.tsx
+++ b/omechu-app/src/app/(omechu)/mypage/mukburim-log/page.tsx
@@ -75,7 +75,7 @@ export default function MukburimLogPage() {
               className={
                 sortOrder === "MostLogged"
                   ? "text-font-high"
-                  : "text-font-extralow"
+                  : "text-font-extra-low"
               }
               onClick={() => setSortOrder("MostLogged")}
             >
@@ -92,7 +92,7 @@ export default function MukburimLogPage() {
               className={clsx(
                 sortOrder === "LatestLogged"
                   ? "text-font-high"
-                  : "text-font-extralow",
+                  : "text-font-extra-low",
                 !supportsLatestSort ? "cursor-not-allowed opacity-50" : "",
               )}
               onClick={() => supportsLatestSort && setSortOrder("LatestLogged")}

--- a/omechu-app/src/app/globals.css
+++ b/omechu-app/src/app/globals.css
@@ -45,7 +45,7 @@ button {
   --color-font-high: #242424;
   --color-font-medium: #5e5e5e;
   --color-font-low: #707070;
-  --color-font-extralow: #919191;
+  --color-font-extra-low: #919191;
   --color-font-placeholder: #a8a8a8;
   --color-font-disabled: #2424243d;
 
@@ -68,6 +68,7 @@ button {
   /* Custom Colors - Line */
   --color-line-strong: #2424241f;
   --color-line-low: #24242414;
+  --color-line-tertiary: rgba(145, 145, 145, 0.12);
 
   /* Custom Colors - Status */
   --color-status-positive: #5ad886;

--- a/omechu-app/src/shared/ui/card/RestaurantCard.tsx
+++ b/omechu-app/src/shared/ui/card/RestaurantCard.tsx
@@ -37,12 +37,12 @@ export const RestaurantCard = ({
             {`${distance}m`}
           </span>
         </div>
-        <div className="text-body-4-regular text-font-extralow flex gap-1">
+        <div className="text-body-4-regular text-font-extra-low flex gap-1">
           <span className="w-fit">{category}</span>
           <span>·</span>
           <span>{`￦ ${price}`}</span>
         </div>
-        <div className="text-body-4-regular text-font-extralow flex">
+        <div className="text-body-4-regular text-font-extra-low flex">
           <span className="text-left whitespace-pre-line">{address}</span>
         </div>
       </div>

--- a/omechu-app/src/widgets/auth/sign-up-form/ui/TermsAgreement.tsx
+++ b/omechu-app/src/widgets/auth/sign-up-form/ui/TermsAgreement.tsx
@@ -86,7 +86,7 @@ const TermsAgreement = ({ setActiveModal }: TermsAgreementProps) => {
           <button
             type="button"
             onClick={() => setActiveModal("service")}
-            className="text-caption-2-regular text-font-extralow"
+            className="text-caption-2-regular text-font-extra-low"
           >
             보기
           </button>
@@ -112,7 +112,7 @@ const TermsAgreement = ({ setActiveModal }: TermsAgreementProps) => {
           <button
             type="button"
             onClick={() => setActiveModal("privacy")}
-            className="text-caption-2-regular text-font-extralow"
+            className="text-caption-2-regular text-font-extra-low"
           >
             보기
           </button>
@@ -138,7 +138,7 @@ const TermsAgreement = ({ setActiveModal }: TermsAgreementProps) => {
           <button
             type="button"
             onClick={() => setActiveModal("location")}
-            className="text-caption-2-regular text-font-extralow"
+            className="text-caption-2-regular text-font-extra-low"
           >
             보기
           </button>

--- a/omechu-app/src/widgets/mypage/ui/CustomerSupportSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/CustomerSupportSection.tsx
@@ -37,10 +37,10 @@ export function CustomerSupportSection() {
               onClick={() => router.push(item.hyperLink)}
               className="flex w-full justify-between"
             >
-              <div className="text-font-extralow text-body-4-regular">
+              <div className="text-font-extra-low text-body-4-regular">
                 {item.listTitle}
               </div>
-              <ArrowIcon className="text-font-extralow" width={9} height={15} />
+              <ArrowIcon className="text-font-extra-low" width={9} height={15} />
             </button>
           </li>
         ))}

--- a/omechu-app/src/widgets/mypage/ui/CustomerSupportSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/CustomerSupportSection.tsx
@@ -40,7 +40,11 @@ export function CustomerSupportSection() {
               <div className="text-font-extra-low text-body-4-regular">
                 {item.listTitle}
               </div>
-              <ArrowIcon className="text-font-extra-low" width={9} height={15} />
+              <ArrowIcon
+                className="text-font-extra-low"
+                width={9}
+                height={15}
+              />
             </button>
           </li>
         ))}

--- a/omechu-app/src/widgets/mypage/ui/DatePicker/CustomInput.tsx
+++ b/omechu-app/src/widgets/mypage/ui/DatePicker/CustomInput.tsx
@@ -14,7 +14,7 @@ export const CustomInput = forwardRef<
     onClick={onClick}
     ref={ref}
     className={cn(
-      "border-font-extralow bg-background-secondary text-body-4-regular relative flex h-10 w-37.5 items-center rounded-[10px] border pl-5",
+      "border-font-extra-low bg-background-secondary text-body-4-regular relative flex h-10 w-37.5 items-center rounded-[10px] border pl-5",
       value ? "text-font-high" : "text-font-placeholder",
     )}
   >

--- a/omechu-app/src/widgets/mypage/ui/PeriodTap.tsx
+++ b/omechu-app/src/widgets/mypage/ui/PeriodTap.tsx
@@ -22,7 +22,7 @@ type Period = (typeof PERIOD_OPTIONS)[number];
 export function PeriodTap({ value, onChange }: PeriodTapProps) {
   return (
     <section className="h-12 overflow-x-auto px-5 pb-2.5">
-      <div className="border-font-extralow relative flex h-full w-max flex-nowrap items-end gap-4 border-b">
+      <div className="border-font-extra-low relative flex h-full w-max flex-nowrap items-end gap-4 border-b">
         {PERIOD_OPTIONS.map((item) => (
           <button
             key={item}
@@ -31,7 +31,7 @@ export function PeriodTap({ value, onChange }: PeriodTapProps) {
               "shrink-0 px-1.75 pb-2.5 whitespace-nowrap",
               value === item
                 ? "text-caption-1-medium border-foundation-grey-darker text-grey-darker relative top-px border-b-2"
-                : "text-body-4-medium text-font-extralow",
+                : "text-body-4-medium text-font-extra-low",
             )}
           >
             {item}

--- a/omechu-app/src/widgets/mypage/ui/SetAlarmSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/SetAlarmSection.tsx
@@ -40,7 +40,7 @@ export function SetAlarmSection() {
         className="absolute right-4 bottom-4"
         onClick={() => router.push("/mypage/alarm-setting")}
       >
-        <ArrowIcon className="text-font-extralow" width={9} height={15} />
+        <ArrowIcon className="text-font-extra-low" width={9} height={15} />
       </button>
     </section>
   );

--- a/omechu-app/src/widgets/mypage/ui/UserInfoSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/UserInfoSection.tsx
@@ -88,8 +88,8 @@ export function UserInfoSection({
           onClick={() => router.push("/mypage/recommended-list")}
           className="border-font-placeholder flex h-14 w-42 flex-1 items-center justify-center gap-2 border-r"
         >
-          <div className="border-font-extralow flex h-5 w-5 items-center justify-center rounded-full border">
-            <WriteIcon className="text-font-extralow w-3" />
+          <div className="border-font-extra-low flex h-5 w-5 items-center justify-center rounded-full border">
+            <WriteIcon className="text-font-extra-low w-3" />
           </div>
           <span>추천 목록 관리</span>
         </button>
@@ -97,8 +97,8 @@ export function UserInfoSection({
           onClick={() => router.push("/mypage/mukburim-log")}
           className="flex h-14 w-42 items-center justify-center gap-2"
         >
-          <div className="border-font-extralow flex h-5 w-5 items-center justify-center rounded-full border">
-            <HistoryRoundedIcon className="text-font-extralow mt-px ml-px w-3.5" />
+          <div className="border-font-extra-low flex h-5 w-5 items-center justify-center rounded-full border">
+            <HistoryRoundedIcon className="text-font-extra-low mt-px ml-px w-3.5" />
           </div>
           <span>먹부림 기록</span>
         </button>

--- a/omechu-app/src/widgets/mypage/ui/terms/TermForLocationInfo.tsx
+++ b/omechu-app/src/widgets/mypage/ui/terms/TermForLocationInfo.tsx
@@ -26,7 +26,7 @@ export function TermForLocationInfo() {
               <span>조</span>
               <span>({item.about})</span>
             </span>
-            <div className="text-body-4-medium text-font-extralow mb-4 px-2 leading-6 whitespace-pre-line">
+            <div className="text-body-4-medium text-font-extra-low mb-4 px-2 leading-6 whitespace-pre-line">
               {item.content}
             </div>
           </div>
@@ -42,7 +42,7 @@ export function TermForLocationInfo() {
               </span>
             )}
             {item.index ? (
-              <div className="text-body-4-medium text-font-extralow mb-4 px-2 leading-6 whitespace-pre-line">
+              <div className="text-body-4-medium text-font-extra-low mb-4 px-2 leading-6 whitespace-pre-line">
                 {item.content}
               </div>
             ) : (

--- a/omechu-app/src/widgets/mypage/ui/terms/TermForPersonalInfo.tsx
+++ b/omechu-app/src/widgets/mypage/ui/terms/TermForPersonalInfo.tsx
@@ -26,7 +26,7 @@ export function TermForPersonalInfo() {
               <span>조</span>
               <span>({item.about})</span>
             </span>
-            <div className="text-body-4-medium text-font-extralow mb-4 px-2 leading-6 whitespace-pre-line">
+            <div className="text-body-4-medium text-font-extra-low mb-4 px-2 leading-6 whitespace-pre-line">
               {item.content}
             </div>
           </div>
@@ -42,7 +42,7 @@ export function TermForPersonalInfo() {
               </span>
             )}
             {item.index ? (
-              <div className="text-body-4-medium text-font-extralow mb-4 px-2 leading-6 whitespace-pre-line">
+              <div className="text-body-4-medium text-font-extra-low mb-4 px-2 leading-6 whitespace-pre-line">
                 {item.content}
               </div>
             ) : (

--- a/omechu-app/src/widgets/mypage/ui/terms/TermForService.tsx
+++ b/omechu-app/src/widgets/mypage/ui/terms/TermForService.tsx
@@ -26,7 +26,7 @@ export function TermForService() {
               <span>조</span>
               <span>({item.about})</span>
             </span>
-            <div className="text-body-4-medium text-font-extralow mb-4 px-2 leading-6 whitespace-pre-line">
+            <div className="text-body-4-medium text-font-extra-low mb-4 px-2 leading-6 whitespace-pre-line">
               {item.content}
             </div>
           </div>
@@ -42,7 +42,7 @@ export function TermForService() {
               </span>
             )}
             {item.index ? (
-              <div className="text-body-4-medium text-font-extralow mb-4 px-2 leading-6 whitespace-pre-line">
+              <div className="text-body-4-medium text-font-extra-low mb-4 px-2 leading-6 whitespace-pre-line">
                 {item.content}
               </div>
             ) : (


### PR DESCRIPTION
- Closes #226

---

## 📌 PR 설명

Figma 디자인 시스템(Color - Semantic)과 `globals.css`의 토큰 네이밍 일치 작업

- [x] `--color-font-extralow` → `--color-font-extra-low` (하이픈 추가)
- [x] `--color-line-tertiary: rgba(145, 145, 145, 0.12)` 추가
- [x] 코드베이스 전체에서 `font-extralow` → `font-extra-low` 일괄 변경 (14개 파일)

### 변경 대상 파일
- `src/app/globals.css` - 디자인 토큰 수정
- `src/app/(omechu)/mypage/...` - 마이페이지 관련 컴포넌트
- `src/shared/ui/card/RestaurantCard.tsx`
- `src/widgets/auth/sign-up-form/ui/TermsAgreement.tsx`
- `src/widgets/mypage/ui/...` - 마이페이지 위젯들

### 유지 항목
- `--color-brand-logo` - Figma 수정 대상으로 유지
- `--color-status-error` - 코드에서 사용 중이므로 유지

---

## 📷 스크린샷

| 변경 전 | 변경 후 |
|--------|--------|
| `--color-font-extralow` | `--color-font-extra-low` |
| (없음) | `--color-line-tertiary` |

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

Figma 디자인 참고: https://www.figma.com/design/v6f7LokIusVVeZS2QiicRY/2_UI?node-id=5765-16320