### PR TITLE
[FEAT] 기본 SEO 세팅 및 PWA manifest 설정

### DIFF
--- a/omechu-app/.env.example
+++ b/omechu-app/.env.example
@@ -1,6 +1,9 @@
 # API Configuration
 NEXT_PUBLIC_API_URL=http://localhost:8080
 
+# Site URL (for SEO metadata)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
 # Kakao Map API
 NEXT_PUBLIC_KAKAO_MAP_API_KEY=your_kakao_map_api_key_here
 

--- a/omechu-app/src/app/layout.tsx
+++ b/omechu-app/src/app/layout.tsx
@@ -14,8 +14,24 @@ const notoSansKR = Noto_Sans_KR({
 });
 
 export const metadata: Metadata = {
-  title: "오메추",
-  description: "오늘 뭐 먹지? Omechu가 추천해드려요!",
+  metadataBase: new URL("https://omechu.log8.kr"),
+  title: {
+    default: "오메추 | 오늘 뭐 먹지? 메뉴 추천 서비스",
+    template: "%s | 오메추",
+  },
+  description:
+    "당신의 취향과 상황을 분석하여 오늘 딱 맞는 메뉴와 주변 맛집을 추천해드립니다.",
+  keywords: [
+    "메뉴추천",
+    "오늘뭐먹지",
+    "맛집추천",
+    "오메추",
+    "점심메뉴",
+    "저녁메뉴",
+    "음식추천",
+  ],
+  authors: [{ name: "OMECHU Team" }],
+  creator: "OMECHU Team",
   icons: {
     icon: [
       { url: "/logo/logo.png", sizes: "32x32", type: "image/png" },
@@ -24,7 +40,42 @@ export const metadata: Metadata = {
     ],
     apple: "/logo/logo.png",
   },
-  manifest: "/manifest.webmanifest",
+  openGraph: {
+    title: "오메추 - 오늘 뭐 먹지?",
+    description: "취향 저격 메뉴 추천 서비스",
+    url: "https://omechu.log8.kr",
+    siteName: "오메추",
+    locale: "ko_KR",
+    type: "website",
+    images: [
+      {
+        url: "/logo/logo.png",
+        width: 512,
+        height: 512,
+        alt: "오메추 로고",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary",
+    title: "오메추 - 오늘 뭐 먹지?",
+    description: "당신의 완벽한 식사를 위한 추천 서비스",
+    images: ["/logo/logo.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  alternates: {
+    canonical: "/",
+  },
 };
 
 export const viewport = {

--- a/omechu-app/src/app/layout.tsx
+++ b/omechu-app/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Noto_Sans_KR } from "next/font/google";
 import type { Metadata } from "next";
 
 import { Providers } from "@/app/providers";
+import { BASE_URL } from "@/shared/constants/url";
 
 const notoSansKR = Noto_Sans_KR({
   weight: ["400", "700"],
@@ -14,7 +15,7 @@ const notoSansKR = Noto_Sans_KR({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://omechu.log8.kr"),
+  metadataBase: new URL(BASE_URL),
   title: {
     default: "오메추 | 오늘 뭐 먹지? 메뉴 추천 서비스",
     template: "%s | 오메추",
@@ -41,9 +42,7 @@ export const metadata: Metadata = {
     apple: "/logo/logo.png",
   },
   openGraph: {
-    title: "오메추 - 오늘 뭐 먹지?",
-    description: "취향 저격 메뉴 추천 서비스",
-    url: "https://omechu.log8.kr",
+    url: BASE_URL,
     siteName: "오메추",
     locale: "ko_KR",
     type: "website",
@@ -58,9 +57,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary",
-    title: "오메추 - 오늘 뭐 먹지?",
-    description: "당신의 완벽한 식사를 위한 추천 서비스",
-    images: ["/logo/logo.png"],
+    images: [{ url: "/logo/logo.png", alt: "오메추 로고" }],
   },
   robots: {
     index: true,

--- a/omechu-app/src/app/manifest.ts
+++ b/omechu-app/src/app/manifest.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "오메추 - 오늘 뭐 먹지?",
+    short_name: "오메추",
+    description: "개인화된 메뉴 및 맛집 추천 서비스",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#FF6B35",
+    orientation: "portrait",
+    icons: [
+      {
+        src: "/logo/logo.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/logo/logo.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/logo/logo.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/omechu-app/src/app/manifest.ts
+++ b/omechu-app/src/app/manifest.ts
@@ -9,7 +9,7 @@ export default function manifest(): MetadataRoute.Manifest {
     display: "standalone",
     background_color: "#ffffff",
     theme_color: "#FF6B35",
-    orientation: "portrait",
+    orientation: "any",
     icons: [
       {
         src: "/logo/logo.png",

--- a/omechu-app/src/app/robots.ts
+++ b/omechu-app/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://omechu.log8.kr/sitemap.xml",
+  };
+}

--- a/omechu-app/src/app/robots.ts
+++ b/omechu-app/src/app/robots.ts
@@ -1,11 +1,13 @@
 import type { MetadataRoute } from "next";
 
+import { BASE_URL } from "@/shared/constants/url";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://omechu.log8.kr/sitemap.xml",
+    sitemap: `${BASE_URL}/sitemap.xml`,
   };
 }

--- a/omechu-app/src/app/sitemap.ts
+++ b/omechu-app/src/app/sitemap.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://omechu.log8.kr";
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/signup`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/fullmenu`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/restaurant`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+  ];
+}

--- a/omechu-app/src/app/sitemap.ts
+++ b/omechu-app/src/app/sitemap.ts
@@ -1,35 +1,35 @@
 import type { MetadataRoute } from "next";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://omechu.log8.kr";
+import { BASE_URL } from "@/shared/constants/url";
 
+export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: baseUrl,
+      url: BASE_URL,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,
     },
     {
-      url: `${baseUrl}/login`,
+      url: `${BASE_URL}/login`,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.5,
     },
     {
-      url: `${baseUrl}/signup`,
+      url: `${BASE_URL}/signup`,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.5,
     },
     {
-      url: `${baseUrl}/fullmenu`,
+      url: `${BASE_URL}/fullmenu`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/restaurant`,
+      url: `${BASE_URL}/restaurant`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,

--- a/omechu-app/src/shared/constants/url.ts
+++ b/omechu-app/src/shared/constants/url.ts
@@ -1,1 +1,2 @@
-export const BASE_URL = "https://omechu.log8.kr";
+export const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://omechu.log8.kr";

--- a/omechu-app/src/shared/constants/url.ts
+++ b/omechu-app/src/shared/constants/url.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = "https://omechu.log8.kr";


### PR DESCRIPTION
- Closes #267

---

## 📌 PR 설명

기본 SEO 설정과 PWA manifest를 추가합니다.

- [x] `app/robots.ts` 생성 - 모든 검색엔진 봇 허용
- [x] `app/sitemap.ts` 생성 - 기본 정적 라우트 sitemap
- [x] `app/manifest.ts` 생성 - PWA 기본 설정
- [x] `layout.tsx` 메타데이터 강화 - OpenGraph, Twitter Card, keywords

---

## 📷 스크린샷

N/A (메타데이터 설정)

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.ts)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

- Next.js 16 App Router의 파일 기반 메타데이터 규칙 적용
- 빌드 결과: `/robots.txt`, `/sitemap.xml`, `/manifest.webmanifest` 정상 생성
- 모든 검색엔진 봇 허용 (Google, Naver 등)