### PR TITLE
[FIX] ProtectedRoute Zustand 하이드레이션 레이스 컨디션 수정

### DIFF
--- a/omechu-app/src/app/providers/ProtectedRoute.tsx
+++ b/omechu-app/src/app/providers/ProtectedRoute.tsx
@@ -36,9 +36,9 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
       checkAuthAndProceed(useAuthStore.getState().isLoggedIn);
     });
 
-    // 이미 하이드레이션이 완료된 경우
+    // 이미 하이드레이션이 완료된 경우 (store에서 직접 읽어 stale 클로저 방지)
     if (useAuthStore.persist.hasHydrated()) {
-      checkAuthAndProceed(isLoggedIn);
+      checkAuthAndProceed(useAuthStore.getState().isLoggedIn);
     }
 
     return () => {


### PR DESCRIPTION
- Closes #289

---

## 📌 PR 설명

`ProtectedRoute`에서 Zustand persist 하이드레이션 타이밍 이슈로 로그인 상태임에도 `/mypage` 접근 시 `/mainpage`로 잘못 리다이렉트되는 버그를 수정합니다.

- [x] `hasHydrated()` 분기에서 React 훅의 stale `isLoggedIn` 대신 `useAuthStore.getState().isLoggedIn`으로 store 직접 참조
- [x] `onFinishHydration` 콜백(36행)과 동일한 패턴으로 통일

### 원인 분석

`useEffect`가 실행되는 시점에 Zustand persist 마이크로태스크는 완료되어 `hasHydrated() === true`이지만, React 훅의 `isLoggedIn`은 아직 리렌더 전이라 초기값 `false`를 유지합니다.

```
/mypage → ProtectedRoute(isLoggedIn=false, stale) → /login
       → OnboardingGuard(isLoggedIn=true + inAuthSection) → /mainpage
```

### 변경 내용

```diff
- checkAuthAndProceed(isLoggedIn);
+ checkAuthAndProceed(useAuthStore.getState().isLoggedIn);
```

---

## 📷 스크린샷

UI 변경 없음 (라우팅 로직 수정)

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

- 변경 범위: `src/app/providers/ProtectedRoute.tsx` 1줄 (+ 코멘트 1줄)
- `onFinishHydration` 콜백은 이미 `getState()`로 올바르게 작성되어 있었으며, `hasHydrated()` 분기만 동일 패턴으로 통일
- ESLint, Prettier 통과 확인