### PR TITLE
[FIX] 로그아웃 시 React Query 캐시 클리어 및 프로필 쿼리키 통일

### DIFF
--- a/omechu-app/src/app/(auth)/auth/callback/[provider]/page.tsx
+++ b/omechu-app/src/app/(auth)/auth/callback/[provider]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { getCurrentUserWithToken, useAuthStore } from "@/entities/user";
 import { Toast, useToast } from "@/shared";
+import { queryClient } from "@/shared/lib/queryClient";
 
 export default function OAuthCallbackPage() {
   return (
@@ -75,10 +76,9 @@ function CallbackContent() {
       }
 
       try {
-        // 1. 토큰으로 유저 정보 조회
         const user = await getCurrentUserWithToken(accessToken);
 
-        // 2. Zustand store에 저장
+        queryClient.clear();
         useAuthStore.getState().login({
           accessToken,
           refreshToken: refreshToken || "",

--- a/omechu-app/src/app/(auth)/login/email/page.tsx
+++ b/omechu-app/src/app/(auth)/login/email/page.tsx
@@ -52,19 +52,11 @@ export default function EmailLoginPage() {
   const onSubmit = useCallback(
     (data: LoginFormValues) => {
       login(data, {
-        onSuccess: async (res) => {
+        onSuccess: async () => {
           try {
-            const userKey = res?.userId ?? "me";
-
-            // 프로필 prefetch로 화면 로딩 최적화
             await queryClient.prefetchQuery({
-              queryKey: ["profile", userKey],
+              queryKey: ["user", "profile"],
               queryFn: fetchProfile,
-            });
-
-            queryClient.invalidateQueries({
-              queryKey: ["profile"],
-              exact: false,
             });
             justLoggedInRef.current = true;
           } catch (e) {

--- a/omechu-app/src/entities/user/lib/hooks/useAuth.ts
+++ b/omechu-app/src/entities/user/lib/hooks/useAuth.ts
@@ -35,21 +35,18 @@ export const useLoginMutation = () => {
         axiosInstance.defaults.headers.common.Authorization = `Bearer ${tokens.accessToken}`;
       }
 
-      // 3) 프로필 정보 prefetch (프로필 로딩 최적화)
       try {
         const profile = await queryClient.fetchQuery({
-          queryKey: ["user", "me"],
+          queryKey: ["user", "profile"],
           queryFn: authApi.getCurrentUser,
-          staleTime: 1000 * 60 * 10, // 10분 신선
+          staleTime: 1000 * 60 * 10,
         });
-        // 프로필 데이터로 스토어 동기화 (email은 기존 값 유지)
         const currentEmail = useAuthStore.getState().user?.email;
         useAuthStore.getState().setUser({
           ...profile,
           email: profile.email ?? currentEmail,
         });
       } catch (err) {
-        // 프로필 조회 실패는 무시 (필요시 화면에서 재조회 가능)
         console.warn(
           "[Auth] 프로필 prefetch 실패:",
           err instanceof Error ? err.message : String(err),
@@ -70,7 +67,6 @@ export const useSignupMutation = () => {
   return useMutation<authApi.SignupSuccessData, Error, SignupFormValues>({
     mutationFn: authApi.signup,
     onSuccess: async (data) => {
-      // 1) 토큰 보관 (signup에서 즉시 토큰 반환)
       const newUser = {
         id: data.id,
         email: data.email,
@@ -82,15 +78,13 @@ export const useSignupMutation = () => {
         user: newUser,
       });
 
-      // 2) axios 인스턴스에 Authorization 주입
       if (data?.accessToken) {
         axiosInstance.defaults.headers.common.Authorization = `Bearer ${data.accessToken}`;
       }
 
-      // 3) 프로필 정보 prefetch (선택사항 - 온보딩에서 조회 가능)
       try {
         const profile = await queryClient.fetchQuery({
-          queryKey: ["user", "me"],
+          queryKey: ["user", "profile"],
           queryFn: authApi.getCurrentUser,
           staleTime: 1000 * 60 * 10,
         });

--- a/omechu-app/src/entities/user/model/auth.store.ts
+++ b/omechu-app/src/entities/user/model/auth.store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
 import type { LoginSuccessData } from "@/entities/user/api/authApi";
+import { queryClient } from "@/shared/lib/queryClient";
 
 interface AuthStoreState {
   isLoggedIn: boolean;
@@ -46,8 +47,8 @@ export const useAuthStore = create<AuthStore>()(
           accessToken: null,
           refreshToken: null,
         });
+        queryClient.clear();
         try {
-          // 모든 user-specific storage 클리어
           localStorage.removeItem(AUTH_STORAGE_KEY);
           localStorage.removeItem("onboarding-storage");
           localStorage.removeItem("tag-data-storage");

--- a/omechu-app/src/shared/lib/queryClient.ts
+++ b/omechu-app/src/shared/lib/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from "@tanstack/react-query";
+
+const STALE_TIME = 60 * 1000;
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: STALE_TIME,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/omechu-app/src/shared/providers/ReactQueryProvider.tsx
+++ b/omechu-app/src/shared/providers/ReactQueryProvider.tsx
@@ -1,30 +1,15 @@
 "use client";
 
-import { useState } from "react";
-
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
-const STALE_TIME = 60 * 1000; // 1분
+import { queryClient } from "@/shared/lib/queryClient";
 
 export function ReactQueryProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: STALE_TIME, // 1분
-            refetchOnWindowFocus: false,
-            // retry: false, // 전역 재시도 비활성화는 권장되지 않으므로, 필요한 쿼리에서 개별적으로 설정해주세요.
-          },
-        },
-      }),
-  );
-
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/omechu-app/src/widgets/auth/login-form/ui/LoginForm.tsx
+++ b/omechu-app/src/widgets/auth/login-form/ui/LoginForm.tsx
@@ -73,26 +73,11 @@ export default function LoginForm() {
   const onSubmit = useCallback(
     (data: LoginFormValues) => {
       login(data, {
-        onSuccess: async (res) => {
+        onSuccess: async () => {
           try {
-            const userKey = res?.userId ?? "me";
-
-            queryClient.setQueryData(["profile", userKey], {
-              id: String(userKey),
-              nickname: "",
-              exercise: "",
-              prefer: [],
-              allergy: [],
-            });
-
             await queryClient.prefetchQuery({
-              queryKey: ["profile", userKey],
+              queryKey: ["user", "profile"],
               queryFn: fetchProfile,
-            });
-
-            queryClient.invalidateQueries({
-              queryKey: ["profile"],
-              exact: false,
             });
             justLoggedInRef.current = true;
           } catch (e) {


### PR DESCRIPTION
- Closes #291

---

## 📌 PR 설명

카카오 로그인 → 로그아웃 → 구글 로그인 시, 이전 계정의 프로필 데이터가 마이페이지에 그대로 표시되는 데이터 누출 버그를 수정합니다.

- [x] `queryClient` 싱글턴 패턴으로 변경 (`shared/lib/queryClient.ts`)
- [x] `ReactQueryProvider`에서 싱글턴 사용하도록 변경
- [x] `auth.store.ts` logout에 `queryClient.clear()` 추가 (모든 로그아웃 경로 커버)
- [x] OAuth 콜백에서 로그인 전 `queryClient.clear()` 호출
- [x] 프로필 쿼리키를 `["user", "profile"]`로 통일

### 원인 분석

로그아웃 시 Zustand store + localStorage는 정상 클리어되지만, React Query 인메모리 캐시가 삭제되지 않았습니다.
`useProfile`의 `staleTime: 10분` + `refetchOnMount: false` 설정으로 새 계정 로그인 후에도 이전 캐시 데이터를 반환합니다.

추가로, 프로필 쿼리키가 3곳에서 전부 달랐습니다:
- `useProfile.ts`: `["user", "profile"]`
- `useAuth.ts`: `["user", "me"]` ← 통일
- `LoginForm.tsx` / `email/page.tsx`: `["profile", userKey]` ← 통일

### 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `shared/lib/queryClient.ts` | 신규: queryClient 싱글턴 |
| `shared/providers/ReactQueryProvider.tsx` | useState 대신 싱글턴 사용 |
| `entities/user/model/auth.store.ts` | logout에 `queryClient.clear()` 추가 |
| `entities/user/lib/hooks/useAuth.ts` | 쿼리키 `["user", "me"]` → `["user", "profile"]` |
| `widgets/auth/login-form/ui/LoginForm.tsx` | 쿼리키 통일 + 불필요한 setQueryData 제거 |
| `app/(auth)/login/email/page.tsx` | 쿼리키 통일 |
| `app/(auth)/auth/callback/[provider]/page.tsx` | 로그인 전 `queryClient.clear()` 추가 |

---

## 📷 스크린샷

UI 변경 없음 (캐시 관리 로직 수정)

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (`queryClient.ts`)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

- `queryClient`를 싱글턴으로 변경한 이유: Zustand store의 `logout()`과 axios interceptor 등 React 컴포넌트 외부에서 캐시를 클리어해야 하므로, `useQueryClient()` hook으로는 접근 불가
- Zustand persist 스토어(auth-storage, onboarding-storage 등)의 로그아웃 클리어는 기존에 정상 동작 확인됨
- ESLint 0 errors, lint-staged 통과 확인