### PR TITLE
[REFACTOR] API 엔드포인트 변경에 따른 SEO 메타데이터 생성 로직 개선

### DIFF
--- a/omechu-app/next-env.d.ts
+++ b/omechu-app/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
@@ -8,13 +8,9 @@ import {
 
 interface LayoutProps {
   children: React.ReactNode;
-  params: Promise<{ menuId: string }>; // Next.js 15+ params는 Promise
+  params: Promise<{ menuId: string }>;
 }
 
-/**
- * 서버 컴포넌트용 메뉴 정보 조회
- * fetch API를 직접 사용하여 SSR에서 안전하게 동작
- */
 async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
   try {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;
@@ -26,7 +22,7 @@ async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: name.trim() }),
-      cache: "no-store", // 항상 최신 데이터 조회
+      cache: "no-store",
     });
 
     if (!response.ok) {
@@ -40,21 +36,14 @@ async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
   }
 }
 
-/**
- * 동적 메타데이터 생성 함수
- * 서버 컴포넌트에서만 작동
- */
 export async function generateMetadata({
   params,
 }: LayoutProps): Promise<Metadata> {
   try {
     const { menuId } = await params;
-    const decodedMenuId = decodeURIComponent(menuId); // URL 디코딩 (%EA%B9%80%EB%B0%A5 → 김밥)
-
-    // 서버 사이드에서 메뉴 정보 조회
+    const decodedMenuId = decodeURIComponent(menuId);
     const menuDetail = await fetchMenuDetail(decodedMenuId);
 
-    // 메타데이터 생성 (페이지 타입: "맞춤 추천")
     return generateMenuMetadata(
       menuDetail,
       "맞춤 추천",
@@ -63,7 +52,6 @@ export async function generateMetadata({
   } catch (error) {
     console.error("Failed to generate metadata:", error);
 
-    // 에러 시 폴백 메타데이터 (검색 인덱싱 방지)
     return {
       title: "맞춤 추천 | 오메추",
       description: "오늘 뭐 먹지? 오메추에서 맞춤 메뉴를 추천받아보세요.",
@@ -72,10 +60,6 @@ export async function generateMetadata({
   }
 }
 
-/**
- * Layout 컴포넌트
- * JSON-LD 구조화 데이터를 <head>에 삽입
- */
 export default async function Layout({ children, params }: LayoutProps) {
   let jsonLd = null;
 

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
@@ -13,12 +13,7 @@ interface LayoutProps {
 
 async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
   try {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-    if (!apiUrl) {
-      throw new Error("NEXT_PUBLIC_API_URL is not defined");
-    }
-
-    const response = await fetch(`${apiUrl}/menu/menu-info`, {
+    const response = await fetch("https://embed.log8.kr/recommend/menu", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: name.trim() }),

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
@@ -1,0 +1,105 @@
+import { Metadata } from "next";
+
+import { MenuDetail } from "@/shared/config/menu";
+import {
+  generateMenuMetadata,
+  generateRecipeJsonLd,
+} from "@/shared/lib/generateMenuMetadata";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ menuId: string }>; // Next.js 15+ params는 Promise
+}
+
+/**
+ * 서버 컴포넌트용 메뉴 정보 조회
+ * fetch API를 직접 사용하여 SSR에서 안전하게 동작
+ */
+async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
+  try {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) {
+      throw new Error("NEXT_PUBLIC_API_URL is not defined");
+    }
+
+    const response = await fetch(`${apiUrl}/menu/menu-info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: name.trim() }),
+      cache: "no-store", // 항상 최신 데이터 조회
+    });
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to fetch menu detail:", error);
+    return null;
+  }
+}
+
+/**
+ * 동적 메타데이터 생성 함수
+ * 서버 컴포넌트에서만 작동
+ */
+export async function generateMetadata({
+  params,
+}: LayoutProps): Promise<Metadata> {
+  try {
+    const { menuId } = await params;
+    const decodedMenuId = decodeURIComponent(menuId); // URL 디코딩 (%EA%B9%80%EB%B0%A5 → 김밥)
+
+    // 서버 사이드에서 메뉴 정보 조회
+    const menuDetail = await fetchMenuDetail(decodedMenuId);
+
+    // 메타데이터 생성 (페이지 타입: "맞춤 추천")
+    return generateMenuMetadata(
+      menuDetail,
+      "맞춤 추천",
+      `/mainpage/result/${menuId}`,
+    );
+  } catch (error) {
+    console.error("Failed to generate metadata:", error);
+
+    // 에러 시 폴백 메타데이터 (검색 인덱싱 방지)
+    return {
+      title: "맞춤 추천 | 오메추",
+      description: "오늘 뭐 먹지? 오메추에서 맞춤 메뉴를 추천받아보세요.",
+      robots: { index: false, follow: true },
+    };
+  }
+}
+
+/**
+ * Layout 컴포넌트
+ * JSON-LD 구조화 데이터를 <head>에 삽입
+ */
+export default async function Layout({ children, params }: LayoutProps) {
+  let jsonLd = null;
+
+  try {
+    const { menuId } = await params;
+    const decodedMenuId = decodeURIComponent(menuId);
+    const menuDetail = await fetchMenuDetail(decodedMenuId);
+
+    if (menuDetail) {
+      jsonLd = generateRecipeJsonLd(menuDetail);
+    }
+  } catch (error) {
+    console.error("Failed to generate JSON-LD:", error);
+  }
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      {children}
+    </>
+  );
+}

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
@@ -1,34 +1,11 @@
 import { Metadata } from "next";
 
-import { MenuDetail } from "@/shared/config/menu";
-import {
-  generateMenuMetadata,
-  generateRecipeJsonLd,
-} from "@/shared/lib/generateMenuMetadata";
+import { generateSummaryMetadata } from "@/shared/lib/generateMenuMetadata";
+import { fetchRecommendMenuForMetadata } from "@/shared/lib/metadataFetchers";
 
 interface LayoutProps {
   children: React.ReactNode;
   params: Promise<{ menuId: string }>;
-}
-
-async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
-  try {
-    const response = await fetch("https://embed.log8.kr/recommend/menu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: name.trim() }),
-      cache: "no-store",
-    });
-
-    if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
-    }
-
-    return await response.json();
-  } catch (error) {
-    console.error("Failed to fetch menu detail:", error);
-    return null;
-  }
 }
 
 export async function generateMetadata({
@@ -37,10 +14,22 @@ export async function generateMetadata({
   try {
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
-    const menuDetail = await fetchMenuDetail(decodedMenuId);
 
-    return generateMenuMetadata(
-      menuDetail,
+    const recommendResponse =
+      await fetchRecommendMenuForMetadata(decodedMenuId);
+
+    if (!recommendResponse || recommendResponse.results.length === 0) {
+      return {
+        title: "맞춤 추천 | 오메추",
+        description: "오늘 뭐 먹지? 오메추에서 맞춤 메뉴를 추천받아보세요.",
+        robots: { index: false, follow: true },
+      };
+    }
+
+    const menuNames = recommendResponse.results.map((item) => item.menu);
+
+    return generateSummaryMetadata(
+      menuNames,
       "맞춤 추천",
       `/mainpage/result/${menuId}`,
     );
@@ -55,30 +44,6 @@ export async function generateMetadata({
   }
 }
 
-export default async function Layout({ children, params }: LayoutProps) {
-  let jsonLd = null;
-
-  try {
-    const { menuId } = await params;
-    const decodedMenuId = decodeURIComponent(menuId);
-    const menuDetail = await fetchMenuDetail(decodedMenuId);
-
-    if (menuDetail) {
-      jsonLd = generateRecipeJsonLd(menuDetail);
-    }
-  } catch (error) {
-    console.error("Failed to generate JSON-LD:", error);
-  }
-
-  return (
-    <>
-      {jsonLd && (
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-      )}
-      {children}
-    </>
-  );
+export default function Layout({ children }: LayoutProps) {
+  return <>{children}</>;
 }

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -1,0 +1,105 @@
+import { Metadata } from "next";
+
+import { MenuDetail } from "@/shared/config/menu";
+import {
+  generateMenuMetadata,
+  generateRecipeJsonLd,
+} from "@/shared/lib/generateMenuMetadata";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ menuId: string }>; // Next.js 15+ params는 Promise
+}
+
+/**
+ * 서버 컴포넌트용 메뉴 정보 조회
+ * fetch API를 직접 사용하여 SSR에서 안전하게 동작
+ */
+async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
+  try {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) {
+      throw new Error("NEXT_PUBLIC_API_URL is not defined");
+    }
+
+    const response = await fetch(`${apiUrl}/menu/menu-info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: name.trim() }),
+      cache: "no-store", // 항상 최신 데이터 조회
+    });
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to fetch menu detail:", error);
+    return null;
+  }
+}
+
+/**
+ * 동적 메타데이터 생성 함수
+ * 서버 컴포넌트에서만 작동
+ */
+export async function generateMetadata({
+  params,
+}: LayoutProps): Promise<Metadata> {
+  try {
+    const { menuId } = await params;
+    const decodedMenuId = decodeURIComponent(menuId); // URL 디코딩 (%EA%B9%80%EB%B0%A5 → 김밥)
+
+    // 서버 사이드에서 메뉴 정보 조회
+    const menuDetail = await fetchMenuDetail(decodedMenuId);
+
+    // 메타데이터 생성 (페이지 타입: "랜덤 추천")
+    return generateMenuMetadata(
+      menuDetail,
+      "랜덤 추천",
+      `/random-recommend/${menuId}`,
+    );
+  } catch (error) {
+    console.error("Failed to generate metadata:", error);
+
+    // 에러 시 폴백 메타데이터 (검색 인덱싱 방지)
+    return {
+      title: "랜덤 추천 | 오메추",
+      description: "오늘 뭐 먹지? 오메추에서 랜덤 메뉴를 추천받아보세요.",
+      robots: { index: false, follow: true },
+    };
+  }
+}
+
+/**
+ * Layout 컴포넌트
+ * JSON-LD 구조화 데이터를 <head>에 삽입
+ */
+export default async function Layout({ children, params }: LayoutProps) {
+  let jsonLd = null;
+
+  try {
+    const { menuId } = await params;
+    const decodedMenuId = decodeURIComponent(menuId);
+    const menuDetail = await fetchMenuDetail(decodedMenuId);
+
+    if (menuDetail) {
+      jsonLd = generateRecipeJsonLd(menuDetail);
+    }
+  } catch (error) {
+    console.error("Failed to generate JSON-LD:", error);
+  }
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      {children}
+    </>
+  );
+}

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -1,3 +1,5 @@
+import { cache } from "react";
+
 import { Metadata } from "next";
 
 import {
@@ -9,6 +11,9 @@ import {
   generateMinimalMetadata,
   generateRecipeJsonLd,
 } from "@/shared/lib/generateMenuMetadata";
+
+const getCachedRandomMenu = cache(fetchRandomMenuForMetadata);
+const getCachedMenuDetail = cache(fetchMenuDetailForMetadata);
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -22,7 +27,7 @@ export async function generateMetadata({
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
 
-    const randomMenu = await fetchRandomMenuForMetadata(decodedMenuId);
+    const randomMenu = await getCachedRandomMenu(decodedMenuId);
 
     if (!randomMenu) {
       return {
@@ -32,7 +37,7 @@ export async function generateMetadata({
       };
     }
 
-    const menuDetail = await fetchMenuDetailForMetadata(randomMenu.name);
+    const menuDetail = await getCachedMenuDetail(randomMenu.name);
 
     if (menuDetail) {
       return generateMenuMetadata(
@@ -65,10 +70,10 @@ export default async function Layout({ children, params }: LayoutProps) {
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
 
-    const randomMenu = await fetchRandomMenuForMetadata(decodedMenuId);
+    const randomMenu = await getCachedRandomMenu(decodedMenuId);
 
     if (randomMenu) {
-      const menuDetail = await fetchMenuDetailForMetadata(randomMenu.name);
+      const menuDetail = await getCachedMenuDetail(randomMenu.name);
 
       if (menuDetail) {
         jsonLd = generateRecipeJsonLd(menuDetail);

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -8,13 +8,9 @@ import {
 
 interface LayoutProps {
   children: React.ReactNode;
-  params: Promise<{ menuId: string }>; // Next.js 15+ params는 Promise
+  params: Promise<{ menuId: string }>;
 }
 
-/**
- * 서버 컴포넌트용 메뉴 정보 조회
- * fetch API를 직접 사용하여 SSR에서 안전하게 동작
- */
 async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
   try {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;
@@ -40,21 +36,14 @@ async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
   }
 }
 
-/**
- * 동적 메타데이터 생성 함수
- * 서버 컴포넌트에서만 작동
- */
 export async function generateMetadata({
   params,
 }: LayoutProps): Promise<Metadata> {
   try {
     const { menuId } = await params;
-    const decodedMenuId = decodeURIComponent(menuId); // URL 디코딩 (%EA%B9%80%EB%B0%A5 → 김밥)
-
-    // 서버 사이드에서 메뉴 정보 조회
+    const decodedMenuId = decodeURIComponent(menuId);
     const menuDetail = await fetchMenuDetail(decodedMenuId);
 
-    // 메타데이터 생성 (페이지 타입: "랜덤 추천")
     return generateMenuMetadata(
       menuDetail,
       "랜덤 추천",
@@ -63,7 +52,6 @@ export async function generateMetadata({
   } catch (error) {
     console.error("Failed to generate metadata:", error);
 
-    // 에러 시 폴백 메타데이터 (검색 인덱싱 방지)
     return {
       title: "랜덤 추천 | 오메추",
       description: "오늘 뭐 먹지? 오메추에서 랜덤 메뉴를 추천받아보세요.",
@@ -72,10 +60,6 @@ export async function generateMetadata({
   }
 }
 
-/**
- * Layout 컴포넌트
- * JSON-LD 구조화 데이터를 <head>에 삽입
- */
 export default async function Layout({ children, params }: LayoutProps) {
   let jsonLd = null;
 

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -1,8 +1,12 @@
 import { Metadata } from "next";
 
-import { MenuDetail } from "@/shared/config/menu";
+import {
+  fetchMenuDetailForMetadata,
+  fetchRandomMenuForMetadata,
+} from "@/shared/lib/metadataFetchers";
 import {
   generateMenuMetadata,
+  generateMinimalMetadata,
   generateRecipeJsonLd,
 } from "@/shared/lib/generateMenuMetadata";
 
@@ -11,39 +15,38 @@ interface LayoutProps {
   params: Promise<{ menuId: string }>;
 }
 
-async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
-  try {
-    const response = await fetch("https://embed.log8.kr/recommend/menu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: name.trim() }),
-      cache: "no-store",
-    });
-
-    if (!response.ok) {
-      throw new Error(`API error: ${response.status}`);
-    }
-
-    return await response.json();
-  } catch (error) {
-    console.error("Failed to fetch menu detail:", error);
-    return null;
-  }
-}
-
 export async function generateMetadata({
   params,
 }: LayoutProps): Promise<Metadata> {
   try {
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
-    const menuDetail = await fetchMenuDetail(decodedMenuId);
 
-    return generateMenuMetadata(
-      menuDetail,
-      "랜덤 추천",
-      `/random-recommend/${menuId}`,
-    );
+    const randomMenu = await fetchRandomMenuForMetadata(decodedMenuId);
+
+    if (!randomMenu) {
+      return {
+        title: "랜덤 추천 | 오메추",
+        description: "오늘 뭐 먹지? 오메추에서 랜덤 메뉴를 추천받아보세요.",
+        robots: { index: false, follow: true },
+      };
+    }
+
+    const menuDetail = await fetchMenuDetailForMetadata(randomMenu.name);
+
+    if (menuDetail) {
+      return generateMenuMetadata(
+        menuDetail,
+        "랜덤 추천",
+        `/random-recommend/${menuId}`,
+      );
+    } else {
+      return generateMinimalMetadata(
+        randomMenu,
+        "랜덤 추천",
+        `/random-recommend/${menuId}`,
+      );
+    }
   } catch (error) {
     console.error("Failed to generate metadata:", error);
 
@@ -61,10 +64,15 @@ export default async function Layout({ children, params }: LayoutProps) {
   try {
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
-    const menuDetail = await fetchMenuDetail(decodedMenuId);
 
-    if (menuDetail) {
-      jsonLd = generateRecipeJsonLd(menuDetail);
+    const randomMenu = await fetchRandomMenuForMetadata(decodedMenuId);
+
+    if (randomMenu) {
+      const menuDetail = await fetchMenuDetailForMetadata(randomMenu.name);
+
+      if (menuDetail) {
+        jsonLd = generateRecipeJsonLd(menuDetail);
+      }
     }
   } catch (error) {
     console.error("Failed to generate JSON-LD:", error);

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -13,16 +13,11 @@ interface LayoutProps {
 
 async function fetchMenuDetail(name: string): Promise<MenuDetail | null> {
   try {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-    if (!apiUrl) {
-      throw new Error("NEXT_PUBLIC_API_URL is not defined");
-    }
-
-    const response = await fetch(`${apiUrl}/menu/menu-info`, {
+    const response = await fetch("https://embed.log8.kr/recommend/menu", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: name.trim() }),
-      cache: "no-store", // 항상 최신 데이터 조회
+      cache: "no-store",
     });
 
     if (!response.ok) {

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -3,14 +3,14 @@ import { cache } from "react";
 import { Metadata } from "next";
 
 import {
-  fetchMenuDetailForMetadata,
-  fetchRandomMenuForMetadata,
-} from "@/shared/lib/metadataFetchers";
-import {
   generateMenuMetadata,
   generateMinimalMetadata,
   generateRecipeJsonLd,
 } from "@/shared/lib/generateMenuMetadata";
+import {
+  fetchMenuDetailForMetadata,
+  fetchRandomMenuForMetadata,
+} from "@/shared/lib/metadataFetchers";
 
 const getCachedRandomMenu = cache(fetchRandomMenuForMetadata);
 const getCachedMenuDetail = cache(fetchMenuDetailForMetadata);

--- a/omechu-app/src/shared/lib/generateMenuMetadata.ts
+++ b/omechu-app/src/shared/lib/generateMenuMetadata.ts
@@ -3,18 +3,11 @@ import { Metadata } from "next";
 import { MenuDetail } from "@/shared/config/menu";
 import { BASE_URL } from "@/shared/constants/url";
 
-/**
- * 메뉴 상세 정보를 기반으로 메타데이터 생성
- * @param menuDetail - 메뉴 상세 정보 (null인 경우 폴백 메타데이터 반환)
- * @param pageType - "랜덤 추천" | "맞춤 추천"
- * @param currentPath - 현재 페이지 경로 (canonical URL용)
- */
 export function generateMenuMetadata(
   menuDetail: MenuDetail | null,
   pageType: "랜덤 추천" | "맞춤 추천",
   currentPath: string,
 ): Metadata {
-  // MenuDetail이 null이면 폴백 메타데이터 반환
   if (!menuDetail) {
     return {
       title: `${pageType} | 오메추`,
@@ -26,18 +19,14 @@ export function generateMenuMetadata(
   const { name, description, image_link, allergic, calory, protein } =
     menuDetail;
 
-  // 페이지 타이틀: "김밥 맞춤 추천"
   const title = `${name} ${pageType}`;
 
-  // 메타 설명: 메뉴 설명 + 영양 정보 (150-160자 제한)
   const metaDescription = description
     ? `${description.slice(0, 100)} | 칼로리 ${calory}, 단백질 ${protein}g`
     : `${name} 메뉴 정보와 주변 맛집을 확인하세요. 칼로리 ${calory}kcal`;
 
-  // OG 이미지: 메뉴 이미지 또는 기본 이미지
   const ogImage = image_link || "/og/og-image.png";
 
-  // 키워드: 메뉴명, 알레르기 정보, 기본 키워드
   const keywords = [
     name,
     "메뉴추천",
@@ -47,7 +36,7 @@ export function generateMenuMetadata(
   ];
 
   return {
-    title, // 루트 layout의 template에 의해 " | 오메추" 자동 추가
+    title,
     description: metaDescription,
     keywords,
     openGraph: {
@@ -82,10 +71,6 @@ export function generateMenuMetadata(
   };
 }
 
-/**
- * Schema.org Recipe JSON-LD 생성
- * 구글 검색 리치 스니펫에 활용됨
- */
 export function generateRecipeJsonLd(menuDetail: MenuDetail) {
   const { name, description, image_link, calory, protein, carbo, fat } =
     menuDetail;
@@ -102,6 +87,109 @@ export function generateRecipeJsonLd(menuDetail: MenuDetail) {
       proteinContent: protein ? `${protein}g` : undefined,
       carbohydrateContent: carbo ? `${carbo}g` : undefined,
       fatContent: fat ? `${fat}g` : undefined,
+    },
+  };
+}
+
+export function generateSummaryMetadata(
+  menuNames: string[],
+  pageType: "랜덤 추천" | "맞춤 추천",
+  currentPath: string,
+): Metadata {
+  if (menuNames.length === 0) {
+    return {
+      title: `${pageType} | 오메추`,
+      description: "오늘 뭐 먹지? 오메추에서 메뉴를 추천받아보세요.",
+      robots: { index: false, follow: true },
+    };
+  }
+
+  const displayNames = menuNames.slice(0, 5);
+  const menuText = displayNames.join(", ");
+  const title = `${menuText} ${pageType}`;
+
+  const description =
+    menuNames.length > 5
+      ? `${menuText} 외 ${menuNames.length - 5}개 메뉴를 추천합니다.`
+      : `${menuText} 메뉴를 추천합니다.`;
+
+  return {
+    title,
+    description,
+    keywords: [...menuNames, "메뉴추천", "맛집", "오늘뭐먹지"],
+    openGraph: {
+      title,
+      description,
+      url: `${BASE_URL}${currentPath}`,
+      siteName: "오메추",
+      locale: "ko_KR",
+      type: "website",
+      images: [
+        {
+          url: "/og/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "오메추 메뉴 추천",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ["/og/og-image.png"],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    alternates: {
+      canonical: `${BASE_URL}${currentPath}`,
+    },
+  };
+}
+
+export function generateMinimalMetadata(
+  randomMenu: { name: string; image_link: string | null },
+  pageType: "랜덤 추천",
+  currentPath: string,
+): Metadata {
+  const { name, image_link } = randomMenu;
+  const title = `${name} ${pageType}`;
+  const description = `${name} 메뉴를 추천받아보세요.`;
+
+  return {
+    title,
+    description,
+    keywords: [name, "메뉴추천", "맛집", "오늘뭐먹지"],
+    openGraph: {
+      title,
+      description,
+      url: `${BASE_URL}${currentPath}`,
+      siteName: "오메추",
+      locale: "ko_KR",
+      type: "website",
+      images: [
+        {
+          url: image_link || "/og/og-image.png",
+          width: 800,
+          height: 600,
+          alt: `${name} 이미지`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image_link || "/og/og-image.png"],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    alternates: {
+      canonical: `${BASE_URL}${currentPath}`,
     },
   };
 }

--- a/omechu-app/src/shared/lib/generateMenuMetadata.ts
+++ b/omechu-app/src/shared/lib/generateMenuMetadata.ts
@@ -3,6 +3,8 @@ import { Metadata } from "next";
 import { MenuDetail } from "@/shared/config/menu";
 import { BASE_URL } from "@/shared/constants/url";
 
+const MAX_DISPLAY_MENUS = 5;
+
 export function generateMenuMetadata(
   menuDetail: MenuDetail | null,
   pageType: "랜덤 추천" | "맞춤 추천",
@@ -104,13 +106,13 @@ export function generateSummaryMetadata(
     };
   }
 
-  const displayNames = menuNames.slice(0, 5);
+  const displayNames = menuNames.slice(0, MAX_DISPLAY_MENUS);
   const menuText = displayNames.join(", ");
   const title = `${menuText} ${pageType}`;
 
   const description =
-    menuNames.length > 5
-      ? `${menuText} 외 ${menuNames.length - 5}개 메뉴를 추천합니다.`
+    menuNames.length > MAX_DISPLAY_MENUS
+      ? `${menuText} 외 ${menuNames.length - MAX_DISPLAY_MENUS}개 메뉴를 추천합니다.`
       : `${menuText} 메뉴를 추천합니다.`;
 
   return {

--- a/omechu-app/src/shared/lib/generateMenuMetadata.ts
+++ b/omechu-app/src/shared/lib/generateMenuMetadata.ts
@@ -24,7 +24,7 @@ export function generateMenuMetadata(
   const title = `${name} ${pageType}`;
 
   const metaDescription = description
-    ? `${description.slice(0, 100)} | 칼로리 ${calory}, 단백질 ${protein}g`
+    ? `${description.slice(0, 100)} | 칼로리 ${calory}kcal, 단백질 ${protein}g`
     : `${name} 메뉴 정보와 주변 맛집을 확인하세요. 칼로리 ${calory}kcal`;
 
   const ogImage = image_link || "/og/og-image.png";

--- a/omechu-app/src/shared/lib/generateMenuMetadata.ts
+++ b/omechu-app/src/shared/lib/generateMenuMetadata.ts
@@ -1,0 +1,107 @@
+import { Metadata } from "next";
+
+import { MenuDetail } from "@/shared/config/menu";
+import { BASE_URL } from "@/shared/constants/url";
+
+/**
+ * 메뉴 상세 정보를 기반으로 메타데이터 생성
+ * @param menuDetail - 메뉴 상세 정보 (null인 경우 폴백 메타데이터 반환)
+ * @param pageType - "랜덤 추천" | "맞춤 추천"
+ * @param currentPath - 현재 페이지 경로 (canonical URL용)
+ */
+export function generateMenuMetadata(
+  menuDetail: MenuDetail | null,
+  pageType: "랜덤 추천" | "맞춤 추천",
+  currentPath: string,
+): Metadata {
+  // MenuDetail이 null이면 폴백 메타데이터 반환
+  if (!menuDetail) {
+    return {
+      title: `${pageType} | 오메추`,
+      description: "오늘 뭐 먹지? 오메추에서 메뉴를 추천받아보세요.",
+      robots: { index: false, follow: true },
+    };
+  }
+
+  const { name, description, image_link, allergic, calory, protein } =
+    menuDetail;
+
+  // 페이지 타이틀: "김밥 맞춤 추천"
+  const title = `${name} ${pageType}`;
+
+  // 메타 설명: 메뉴 설명 + 영양 정보 (150-160자 제한)
+  const metaDescription = description
+    ? `${description.slice(0, 100)} | 칼로리 ${calory}, 단백질 ${protein}g`
+    : `${name} 메뉴 정보와 주변 맛집을 확인하세요. 칼로리 ${calory}kcal`;
+
+  // OG 이미지: 메뉴 이미지 또는 기본 이미지
+  const ogImage = image_link || "/og/og-image.png";
+
+  // 키워드: 메뉴명, 알레르기 정보, 기본 키워드
+  const keywords = [
+    name,
+    "메뉴추천",
+    "맛집",
+    "오늘뭐먹지",
+    ...(allergic || []),
+  ];
+
+  return {
+    title, // 루트 layout의 template에 의해 " | 오메추" 자동 추가
+    description: metaDescription,
+    keywords,
+    openGraph: {
+      title,
+      description: metaDescription,
+      url: `${BASE_URL}${currentPath}`,
+      siteName: "오메추",
+      locale: "ko_KR",
+      type: "website",
+      images: [
+        {
+          url: ogImage,
+          width: image_link ? 800 : 1200,
+          height: image_link ? 600 : 630,
+          alt: `${name} 이미지`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: metaDescription,
+      images: [ogImage],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    alternates: {
+      canonical: `${BASE_URL}${currentPath}`,
+    },
+  };
+}
+
+/**
+ * Schema.org Recipe JSON-LD 생성
+ * 구글 검색 리치 스니펫에 활용됨
+ */
+export function generateRecipeJsonLd(menuDetail: MenuDetail) {
+  const { name, description, image_link, calory, protein, carbo, fat } =
+    menuDetail;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    name,
+    description: description || `${name} 요리 정보`,
+    image: image_link || undefined,
+    nutrition: {
+      "@type": "NutritionInformation",
+      calories: calory ? `${calory} calories` : undefined,
+      proteinContent: protein ? `${protein}g` : undefined,
+      carbohydrateContent: carbo ? `${carbo}g` : undefined,
+      fatContent: fat ? `${fat}g` : undefined,
+    },
+  };
+}

--- a/omechu-app/src/shared/lib/metadataFetchers.ts
+++ b/omechu-app/src/shared/lib/metadataFetchers.ts
@@ -1,0 +1,65 @@
+import type { RandomMenu, MenuListResponse } from "@/entities/menu";
+import { MenuDetail } from "@/shared/config/menu";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "https://omechu-api.log8.kr";
+
+export async function fetchMenuDetailForMetadata(
+  menuName: string,
+): Promise<MenuDetail | null> {
+  try {
+    const response = await fetch(`${API_URL}/menu/menu-info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: menuName.trim() }),
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) return null;
+    const data: MenuDetail = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch menu detail:", error);
+    return null;
+  }
+}
+
+export async function fetchRandomMenuForMetadata(
+  menuName: string,
+): Promise<RandomMenu | null> {
+  try {
+    const response = await fetch(`${API_URL}/menu/recommend/random`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: menuName.trim() }),
+      cache: "no-store",
+    });
+
+    if (!response.ok) return null;
+    const data: RandomMenu = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch random menu:", error);
+    return null;
+  }
+}
+
+export async function fetchRecommendMenuForMetadata(
+  menuName: string,
+): Promise<MenuListResponse | null> {
+  try {
+    const response = await fetch("https://embed.log8.kr/recommend/menu", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: menuName.trim() }),
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) return null;
+    const data: MenuListResponse = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch recommend menu:", error);
+    return null;
+  }
+}

--- a/omechu-app/src/shared/lib/metadataFetchers.ts
+++ b/omechu-app/src/shared/lib/metadataFetchers.ts
@@ -1,7 +1,8 @@
 import type { RandomMenu, MenuListResponse } from "@/entities/menu";
 import { MenuDetail } from "@/shared/config/menu";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://omechu-api.log8.kr";
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const EMBED_API_URL = process.env.NEXT_PUBLIC_EMBED_API_URL;
 
 export async function fetchMenuDetailForMetadata(
   menuName: string,
@@ -47,7 +48,7 @@ export async function fetchRecommendMenuForMetadata(
   menuName: string,
 ): Promise<MenuListResponse | null> {
   try {
-    const response = await fetch("https://embed.log8.kr/recommend/menu", {
+    const response = await fetch(`${EMBED_API_URL}/recommend/menu`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: menuName.trim() }),

--- a/omechu-app/src/shared/lib/metadataFetchers.ts
+++ b/omechu-app/src/shared/lib/metadataFetchers.ts
@@ -1,8 +1,7 @@
 import type { RandomMenu, MenuListResponse } from "@/entities/menu";
 import { MenuDetail } from "@/shared/config/menu";
 
-const API_URL =
-  process.env.NEXT_PUBLIC_API_URL || "https://omechu-api.log8.kr";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://omechu-api.log8.kr";
 
 export async function fetchMenuDetailForMetadata(
   menuName: string,


### PR DESCRIPTION
## [REFACTOR] API 엔드포인트 변경에 따른 SEO 메타데이터 생성 로직 개선 (#302)

- Closes #302

---

## PR 설명

API 엔드포인트 변경으로 인해 메타데이터가 올바르게 생성되지 않는 문제를 해결합니다.

- [x] 서버 컴포넌트용 API fetcher 함수 분리 (`metadataFetchers.ts`)
- [x] 랜덤 추천: 2단계 API 호출로 풍부한 메타데이터 생성
- [x] 맞춤 추천: 여러 메뉴를 요약한 메타데이터 생성
- [x] 코드 중복 제거 및 FSD 아키텍처 준수
- [x] 캐싱 전략 최적화 (랜덤: no-store, 맞춤: 1시간, 상세: 24시간)

### 원인 분석 및 수정 내용

#### 1. 랜덤 추천 메타데이터 생성 실패

**원인**: 
- API 엔드포인트가 `/menu/menu-info` → `/menu/recommend/random`으로 변경
- 새 API는 `{name, image_link}` 반환 (영양 정보 없음)
- URL의 메뉴와 다른 메뉴를 반환 (예: URL `/김밥` → API 응답 `마카롱`)

**수정**: 2단계 API 호출 파이프라인 구현
```
1단계: POST /menu/recommend/random {"name": "김밥"}
    → {"name": "마카롱", "image_link": null}
    
2단계: POST /menu/menu-info {"name": "마카롱"}
    → MenuDetail (calory, protein, allergic 등 포함)
    
메타데이터: "마카롱 랜덤 추천 | 칼로리 450kcal, 단백질 5g"
```

**폴백 전략**:
- 2단계 실패 → `generateMinimalMetadata()` (RandomMenu 정보만 사용)
- 1단계 실패 → 기본 폴백 메타데이터

#### 2. 맞춤 추천 메타데이터 타입 불일치

**원인**:
- API 엔드포인트가 `/menu/menu-info` → `/recommend/menu`로 변경
- 새 API는 `{results: [{menu: "우동"}, ...]}` 배열 반환
- 기존 로직은 단일 MenuDetail 타입 기대

**수정**: 여러 메뉴 요약 메타데이터 생성
```
POST /recommend/menu {"name": "김치찌개"}
    → {"results": [{"menu": "우동"}, {"menu": "청국장"}, ...]}
    
메뉴명 추출: ["우동", "청국장", "콩나물국밥"]
    
메타데이터: "우동, 청국장, 콩나물국밥 맞춤 추천 | 오메추"
```

#### 3. 코드 중복 및 하드코딩 제거

**원인**:
- 두 layout.tsx 파일에서 동일한 fetcher 함수 중복
- API URL이 하드코딩됨

**수정**: 
- `shared/lib/metadataFetchers.ts` 생성 → 3개 fetcher 함수 통합
- 환경변수 `NEXT_PUBLIC_API_URL` 사용
- FSD 레이어 규칙 준수 (shared → entities 타입만 import)

### 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `shared/lib/metadataFetchers.ts` | **신규**: 서버 컴포넌트용 API fetcher 함수 3개 |
| `shared/lib/generateMenuMetadata.ts` | `generateSummaryMetadata()`, `generateMinimalMetadata()` 추가 |
| `app/(public)/random-recommend/[menuId]/layout.tsx` | 2단계 API 호출 파이프라인 + JSON-LD 동기화 |
| `app/(public)/mainpage/result/[menuId]/layout.tsx` | 요약형 메타데이터 생성 + JSON-LD 제거 |

### 캐싱 전략

| API 엔드포인트 | 캐싱 정책 | 이유 |
|---------------|----------|------|
| `/menu/recommend/random` | `cache: "no-store"` | 매번 다른 랜덤 결과 |
| `/recommend/menu` | `revalidate: 3600` (1시간) | 동일 컨텍스트 재사용 가능 |
| `/menu/menu-info` | `revalidate: 86400` (24시간) | 정적 데이터 |

### 예상 동작

**랜덤 추천** (`/random-recommend/김밥`):
- 1단계 성공 + 2단계 성공 → "마카롱 랜덤 추천 | 칼로리 450kcal, 단백질 5g"
- 1단계 성공 + 2단계 실패 → "마카롱 랜덤 추천"
- 1단계 실패 → "랜덤 추천 | 오메추" (인덱싱 차단)

**맞춤 추천** (`/mainpage/result/김치찌개`):
- API 성공 (3개 메뉴) → "우동, 청국장, 콩나물국밥 맞춤 추천"
- API 성공 (7개 메뉴) → "메뉴1, 메뉴2, 메뉴3, 메뉴4, 메뉴5 외 2개 메뉴를 추천합니다"
- API 실패 → "맞춤 추천 | 오메추" (인덱싱 차단)

---

## 스크린샷

<img width="533" height="724" alt="스크린샷 2026-02-09 오전 8 46 51" src="https://github.com/user-attachments/assets/09993036-9919-4072-9b18-cb4f4b517647" />


메타데이터 변경이므로 UI 변경 없음. 페이지 소스 확인:

**랜덤 추천 메타데이터** (개발자 도구 > Elements):
```html
<meta property="og:title" content="마카롱 랜덤 추천" />
<meta property="og:description" content="달콤하고 부드러운 프랑스 디저트... | 칼로리 450kcal, 단백질 5g" />
<script type="application/ld+json">
{
  "@context": "https://schema.org",
  "@type": "Recipe",
  "name": "마카롱",
  "nutrition": {
    "@type": "NutritionInformation",
    "calories": "450 calories",
    "proteinContent": "5g"
  }
}
</script>
```

**맞춤 추천 메타데이터**:
```html
<meta property="og:title" content="우동, 청국장, 콩나물국밥 맞춤 추천" />
<meta property="og:description" content="우동, 청국장, 콩나물국밥 메뉴를 추천합니다." />
```

---

## FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (`metadataFetchers.ts`, `generateMenuMetadata.ts`)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts) 불필요 (유틸리티 함수만 export)

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities)
- [x] 상대 경로 사용 최소화
- [x] Import 순서 ESLint 규칙 준수

---

## 추가 설명

### 기술적 결정 사항

1. **왜 2단계 API 호출인가?**
   - `/menu/recommend/random`은 메뉴 이름만 반환 (영양 정보 없음)
   - SEO를 위해 풍부한 메타데이터 필요 (칼로리, 단백질 등)
   - `/menu/menu-info`를 추가 호출하여 상세 정보 확보

2. **왜 맞춤 추천은 JSON-LD를 제거했는가?**
   - Schema.org Recipe는 단일 레시피 구조
   - 여러 메뉴 배열은 Recipe 스키마에 부적합
   - 검색엔진이 혼란스러워할 수 있으므로 제거

3. **왜 fetcher를 shared/lib로 분리했는가?**
   - 서버 컴포넌트에서는 axios instance 사용 불가 (window 객체 필요)
   - 두 layout 파일의 중복 제거
   - 환경변수 관리 중앙화

### 테스트 권장사항

- 로컬 개발 서버에서 페이지 소스 확인
- Open Graph Debugger로 메타태그 검증 (https://www.opengraph.xyz/)
- Google Rich Results Test로 JSON-LD 검증
- 다양한 메뉴명으로 테스트 (한글, 영문, 특수문자)

### 후속 작업 제안

- API가 안정화되면 `/menu/recommend/random`이 영양 정보도 반환하도록 백엔드 수정 검토
- 맞춤 추천도 대표 메뉴 1개에 대한 상세 정보를 추가하여 JSON-LD 생성 고려