### PR TITLE
[FIX] 마이페이지 QA UI/UX 개선

### DIFF
--- a/omechu-app/src/app/(private)/mypage/(settings)/account-setting/delete-account/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/account-setting/delete-account/page.tsx
@@ -55,8 +55,8 @@ export default function DeleteAccountPage() {
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
   }, []);
 
   const nickname = profile?.nickname || "회원";
@@ -151,7 +151,7 @@ export default function DeleteAccountPage() {
             </button>
 
             {showDropDown && (
-              <ul className="border-font-disabled absolute z-50 mt-2 flex h-fit w-full flex-col gap-2 overflow-hidden rounded-[10px] border bg-white p-2.5">
+              <ul className="border-font-disabled absolute z-50 mt-2 flex h-fit w-full flex-col gap-2 rounded-[10px] border bg-white p-2.5">
                 {WITHDRAW_REASONS.map((reason) => (
                   <li
                     key={reason}
@@ -159,7 +159,7 @@ export default function DeleteAccountPage() {
                       setSelectedReason(reason);
                       setShowDropDown(false);
                     }}
-                    className="flex cursor-pointer items-center gap-1.5"
+                    className="flex cursor-pointer items-center gap-1.5 py-2"
                   >
                     {selectedReason === reason ? (
                       <CheckIcon />
@@ -168,7 +168,7 @@ export default function DeleteAccountPage() {
                     )}
                     <span
                       className={clsx(
-                        "text-caption-1-regular hover:bg-background-secondary w-full",
+                        "text-caption-1-regular hover:bg-component-default w-full rounded-md px-1",
                         selectedReason === reason
                           ? "text-font-high"
                           : "text-font-placeholder",

--- a/omechu-app/src/app/(private)/mypage/(settings)/account-setting/delete-account/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/account-setting/delete-account/page.tsx
@@ -159,16 +159,16 @@ export default function DeleteAccountPage() {
                       setSelectedReason(reason);
                       setShowDropDown(false);
                     }}
-                    className="flex cursor-pointer items-center gap-1.5 py-2"
+                    className="flex cursor-pointer items-center gap-1.5 py-1"
                   >
                     {selectedReason === reason ? (
                       <CheckIcon />
                     ) : (
-                      <div className="h-5.25 w-5.25" />
+                      <div className="h-5.5 w-5.25" />
                     )}
                     <span
                       className={clsx(
-                        "text-caption-1-regular hover:bg-component-default w-full rounded-md px-1",
+                        "text-caption-1-regular hover:bg-component-default h-full w-full rounded-md px-1",
                         selectedReason === reason
                           ? "text-font-high"
                           : "text-font-placeholder",

--- a/omechu-app/src/app/(private)/mypage/(settings)/account-setting/delete-account/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/account-setting/delete-account/page.tsx
@@ -101,12 +101,12 @@ export default function DeleteAccountPage() {
           <div className="body-3-medium text-font-high">
             {nickname}님, 정말 오메추를 떠나시나요?
           </div>
-          <div className="text-body-4-regular text-font-low flex flex-col gap-4.5 whitespace-pre-line">
-            <span>
-              {`탈퇴하시면 입력하신 개인정보와 메뉴 추천 목록, \n 먹부림 통계 등 모든 활동 정보가 삭제됩니다.`}
+          <div className="text-body-4-regular text-font-low flex flex-col gap-4.5 tracking-tight">
+            <span className="whitespace-pre-line">
+              {`탈퇴하시면 입력하신 개인정보와 메뉴 추천 목록, 먹부림 통계 등 모든 활동 정보가 삭제됩니다.`}
             </span>
-            <span>
-              {`삭제된 데이터는 복구할 수 없으니, 마지막 결정이 \n  맞는지 한 번 더 생각해 주세요.`}
+            <span className="whitespace-pre-line">
+              {`삭제된 데이터는 복구할 수 없으니, 마지막 결정이 맞는지 한 번 더 생각해 주세요.`}
             </span>
           </div>
           <div className="mt-4 flex items-center gap-2.5">

--- a/omechu-app/src/widgets/mypage/ui/UserInfoSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/UserInfoSection.tsx
@@ -54,7 +54,7 @@ export function UserInfoSection({
         </div>
         <div className="flex flex-col gap-2">
           <div className="flex gap-2">
-            <span className="text-font-high text-body-4-regular w-15">
+            <span className="text-font-high text-body-4-regular w-16">
               운동 상태
             </span>
             <span>|</span>
@@ -63,7 +63,7 @@ export function UserInfoSection({
             </span>
           </div>
           <div className="flex gap-2">
-            <span className="text-font-high text-body-4-regular w-15">
+            <span className="text-font-high text-body-4-regular w-16">
               선호 음식
             </span>
             <span>|</span>


### PR DESCRIPTION
## 🔀 Pull Request Title

fix: 마이페이지 QA UI/UX 개선

- Closes #308

<br>

## 📌 PR 설명

마이페이지 QA 과정에서 발견된 UI/UX 이슈들을 수정했습니다.

- [x] 회원탈퇴 드롭다운 '기타' 항목 선택 불가 버그 수정 (외부 클릭 이벤트 race condition 해결)
- [x] 회원탈퇴 페이지 설명 텍스트 줄바꿈 자연스럽게 개선
- [x] 드롭다운 항목 터치 타겟 확대 및 hover 시각적 피드백 추가
- [x] UserInfoSection 라벨 너비 조정 (`w-15` -> `w-16`)

<br>

## 📷 스크린샷

<img width="354" height="239" alt="스크린샷 2026-02-09 오전 9 33 03" src="https://github.com/user-attachments/assets/4f248fbd-303d-4917-a160-af55cfaa0cdf" />

<img width="486" height="550" alt="스크린샷 2026-02-09 오전 9 34 54" src="https://github.com/user-attachments/assets/2450c993-8e20-4e65-b477-c12ab59dd277" />

<img width="391" height="495" alt="스크린샷 2026-02-09 오전 9 54 18" src="https://github.com/user-attachments/assets/0d2475e2-99f8-4307-999d-a87e3803e28d" />

https://github.com/user-attachments/assets/e6852c11-2c05-4487-85fd-e497e29f4703



<br>

## 🔍 추가 설명

**변경 파일:**
| 파일 | 변경 내용 |
|------|-----------|
| `delete-account/page.tsx` | 외부 클릭 `mousedown`->`click` 변경, `overflow-hidden` 제거, 항목 패딩 추가, hover 색상 수정, 텍스트 줄바꿈 개선 |
| `UserInfoSection.tsx` | 운동 상태/선호 음식 라벨 너비 `w-15` -> `w-16` 조정 |


**버그 원인 분석:**
- `mousedown` 이벤트가 `click`보다 먼저 발생하여, 드롭다운 항목의 `onClick`이 실행되기 전에 외부 클릭 핸들러가 드롭다운을 닫는 race condition
- 마지막 항목 '기타'는 아래에 인접 항목이 없어 부정확한 탭이 `<ul>` 패딩에 떨어지면서 특히 취약

**테스트 체크리스트:**
- [x] 회원탈퇴 드롭다운 5개 항목 모두 선택 가능 확인 (특히 '기타')
- [x] 드롭다운 외부 클릭 시 정상 닫힘 확인
- [x] 드롭다운 항목 hover 시 시각적 피드백 확인
- [x] '기타' 선택 + 체크박스 체크 후 확인 버튼 활성화 확인
- [x] 모바일(375px) 뷰포트에서 동일 테스트
- [x] 마이페이지 UserInfoSection 라벨 정렬 확인