### PR TITLE
[FIX] 알림 설정 페이지 API 연동 및 QA 버그 수정

### DIFF
--- a/omechu-app/src/app/(private)/mypage/(settings)/alarm-setting/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/alarm-setting/page.tsx
@@ -45,8 +45,10 @@ export default function AlarmSettingPage() {
     refetchOnWindowFocus: false,
   });
 
-  const masterEnabled = data?.success?.enabled ?? false;
-  const alerts = data?.success?.alerts;
+  const alerts = data?.success;
+  const masterEnabled = alerts
+    ? Object.values(alerts).some((a) => a.enabled)
+    : false;
 
   const toggleMutation = useMutation({
     mutationFn: (enabled: boolean) => toggleMealAlerts(enabled),

--- a/omechu-app/src/app/(private)/mypage/(settings)/alarm-setting/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/alarm-setting/page.tsx
@@ -95,40 +95,6 @@ export default function AlarmSettingPage() {
   const activeAlert: MealAlertItem | undefined =
     activeMealType && alerts ? alerts[activeMealType] : undefined;
 
-  if (isLoading) {
-    return (
-      <>
-        <Header
-          title="알림 설정"
-          onBackClick={() => router.push("/mypage")}
-          showHomeButton={false}
-        />
-        <main className="mt-2 flex h-[80dvh] w-full items-center justify-center">
-          <span className="text-font-low text-body-3-regular">
-            불러오는 중...
-          </span>
-        </main>
-      </>
-    );
-  }
-
-  if (isError || !alerts) {
-    return (
-      <>
-        <Header
-          title="알림 설정"
-          onBackClick={() => router.push("/mypage")}
-          showHomeButton={false}
-        />
-        <main className="mt-2 flex h-[80dvh] w-full items-center justify-center">
-          <span className="text-font-low text-body-3-regular">
-            알림 설정을 불러올 수 없습니다.
-          </span>
-        </main>
-      </>
-    );
-  }
-
   return (
     <>
       <Header
@@ -137,48 +103,62 @@ export default function AlarmSettingPage() {
         showHomeButton={false}
       />
 
-      <main className="relative mt-2 flex h-[80dvh] w-full flex-col pr-6 pl-8">
-        <section className="mt-10 flex w-full flex-col items-start justify-start gap-3">
-          <div className="flex w-full items-center justify-between">
-            <span>식사 시간 알림</span>
-            <ToggleSwitch
-              checked={masterEnabled}
-              onChange={(value) => toggleMutation.mutate(value)}
-            />
-          </div>
-          <div className="text-caption-1-regular text-font-extra-low">
-            매일 식사 시간마다 메뉴를 결정해 드려요.
-          </div>
-          {MEAL_ORDER.map((type) => {
-            const alarm = alerts[type];
-            return (
-              <button
-                key={type}
-                disabled={!masterEnabled}
-                onClick={() => handleOpenTimeModal(type, alarm.time)}
-                className={clsx(
-                  "flex w-full items-center justify-between",
-                  !masterEnabled && "cursor-not-allowed",
-                )}
-              >
-                <span>{MEAL_LABELS[type]}</span>
-                <div className="flex items-center gap-4">
-                  <span
-                    className={
-                      masterEnabled && alarm.enabled
-                        ? "text-brand-primary"
-                        : "text-font-extra-low"
-                    }
-                  >
-                    {masterEnabled && alarm.enabled ? alarm.time : "OFF"}
-                  </span>
-                  <ArrowIcon currentColor="#707070" />
-                </div>
-              </button>
-            );
-          })}
-        </section>
-      </main>
+      {isLoading ? (
+        <main className="mt-2 flex h-[80dvh] w-full items-center justify-center">
+          <span className="text-font-low text-body-3-regular">
+            불러오는 중...
+          </span>
+        </main>
+      ) : isError || !alerts ? (
+        <main className="mt-2 flex h-[80dvh] w-full items-center justify-center">
+          <span className="text-font-low text-body-3-regular">
+            알림 설정을 불러올 수 없습니다.
+          </span>
+        </main>
+      ) : (
+        <main className="relative mt-2 flex h-[80dvh] w-full flex-col pr-6 pl-8">
+          <section className="mt-10 flex w-full flex-col items-start justify-start gap-3">
+            <div className="flex w-full items-center justify-between">
+              <span>식사 시간 알림</span>
+              <ToggleSwitch
+                checked={masterEnabled}
+                onChange={(value) => toggleMutation.mutate(value)}
+              />
+            </div>
+            <div className="text-caption-1-regular text-font-extra-low">
+              매일 식사 시간마다 메뉴를 결정해 드려요.
+            </div>
+            {MEAL_ORDER.map((type) => {
+              const alarm = alerts[type];
+              return (
+                <button
+                  key={type}
+                  disabled={!masterEnabled}
+                  onClick={() => handleOpenTimeModal(type, alarm.time)}
+                  className={clsx(
+                    "flex w-full items-center justify-between",
+                    !masterEnabled && "cursor-not-allowed",
+                  )}
+                >
+                  <span>{MEAL_LABELS[type]}</span>
+                  <div className="flex items-center gap-4">
+                    <span
+                      className={
+                        masterEnabled && alarm.enabled
+                          ? "text-brand-primary"
+                          : "text-font-extra-low"
+                      }
+                    >
+                      {masterEnabled && alarm.enabled ? alarm.time : "OFF"}
+                    </span>
+                    <ArrowIcon currentColor="#707070" />
+                  </div>
+                </button>
+              );
+            })}
+          </section>
+        </main>
+      )}
 
       {isTimeModalOpen && (
         <ModalWrapper>

--- a/omechu-app/src/app/(private)/mypage/(settings)/alarm-setting/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/alarm-setting/page.tsx
@@ -4,34 +4,63 @@ import { useState } from "react";
 
 import { useRouter } from "next/navigation";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
 
+import type {
+  MealAlertItem,
+  MealAlertPatchBody,
+  MealType,
+} from "@/entities/alarm";
+import {
+  getMealAlerts,
+  patchMealAlerts,
+  toggleMealAlerts,
+} from "@/entities/alarm";
 import { Header, ModalWrapper } from "@/shared";
 import { ArrowIcon } from "@/shared/assets/icons";
 import { TimePickerModal, ToggleSwitch } from "@/widgets/mypage/ui";
 
-type MealType = "breakfast" | "lunch" | "dinner";
-
-type MealAlarm = {
-  type: MealType;
-  enabled: boolean;
-  time: string;
+const MEAL_LABELS: Record<MealType, string> = {
+  breakfast: "아침 알림",
+  lunch: "점심 알림",
+  dinner: "저녁 알림",
+  night: "야식 알림",
 };
+
+const MEAL_ORDER: MealType[] = ["breakfast", "lunch", "dinner", "night"];
 
 export default function AlarmSettingPage() {
   const router = useRouter();
-
-  const [isAlarmFeatureEnabled, setIsAlarmFeatureEnabled] = useState(true);
-
-  const [mealAlarms, setMealAlarms] = useState<MealAlarm[]>([
-    { type: "breakfast", enabled: false, time: "07:30" },
-    { type: "lunch", enabled: true, time: "11:30" },
-    { type: "dinner", enabled: true, time: "18:00" },
-  ]);
+  const queryClient = useQueryClient();
 
   const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
   const [activeMealType, setActiveMealType] = useState<MealType | null>(null);
-  const [tempTime, setTempTime] = useState<string>("");
+  const [tempTime, setTempTime] = useState("");
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["user", "meal-alerts"],
+    queryFn: getMealAlerts,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  const masterEnabled = data?.success?.enabled ?? false;
+  const alerts = data?.success?.alerts;
+
+  const toggleMutation = useMutation({
+    mutationFn: (enabled: boolean) => toggleMealAlerts(enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user", "meal-alerts"] });
+    },
+  });
+
+  const patchMutation = useMutation({
+    mutationFn: (body: MealAlertPatchBody) => patchMealAlerts(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user", "meal-alerts"] });
+    },
+  });
 
   const handleOpenTimeModal = (type: MealType, currentTime: string) => {
     setActiveMealType(type);
@@ -47,19 +76,56 @@ export default function AlarmSettingPage() {
 
   const handleConfirmTime = () => {
     if (!activeMealType) return;
-
-    setMealAlarms((prev) =>
-      prev.map((alarm) =>
-        alarm.type === activeMealType
-          ? { ...alarm, time: tempTime, enabled: true }
-          : alarm,
-      ),
+    patchMutation.mutate(
+      { [activeMealType]: { enabled: true, time: tempTime } },
+      { onSuccess: handleCloseModal },
     );
-
-    handleCloseModal();
   };
 
-  const _isMealAlarmEnabled = mealAlarms.some((alarm) => alarm.enabled);
+  const handleTurnOff = () => {
+    if (!activeMealType) return;
+    patchMutation.mutate(
+      { [activeMealType]: { enabled: false } },
+      { onSuccess: handleCloseModal },
+    );
+  };
+
+  const activeAlert: MealAlertItem | undefined =
+    activeMealType && alerts ? alerts[activeMealType] : undefined;
+
+  if (isLoading) {
+    return (
+      <>
+        <Header
+          title="알림 설정"
+          onBackClick={() => router.push("/mypage")}
+          showHomeButton={false}
+        />
+        <main className="mt-2 flex h-[80dvh] w-full items-center justify-center">
+          <span className="text-font-low text-body-3-regular">
+            불러오는 중...
+          </span>
+        </main>
+      </>
+    );
+  }
+
+  if (isError || !alerts) {
+    return (
+      <>
+        <Header
+          title="알림 설정"
+          onBackClick={() => router.push("/mypage")}
+          showHomeButton={false}
+        />
+        <main className="mt-2 flex h-[80dvh] w-full items-center justify-center">
+          <span className="text-font-low text-body-3-regular">
+            알림 설정을 불러올 수 없습니다.
+          </span>
+        </main>
+      </>
+    );
+  }
 
   return (
     <>
@@ -74,54 +140,44 @@ export default function AlarmSettingPage() {
           <div className="flex w-full items-center justify-between">
             <span>식사 시간 알림</span>
             <ToggleSwitch
-              checked={isAlarmFeatureEnabled}
-              onChange={(value) => {
-                setIsAlarmFeatureEnabled(value);
-                if (!value) {
-                  setMealAlarms((prev) =>
-                    prev.map((alarm) => ({ ...alarm, enabled: false })),
-                  );
-                }
-              }}
+              checked={masterEnabled}
+              onChange={(value) => toggleMutation.mutate(value)}
             />
           </div>
           <div className="text-caption-1-regular text-font-extra-low">
             매일 식사 시간마다 메뉴를 결정해 드려요.
           </div>
-          {mealAlarms.map((alarm) => (
-            <button
-              key={alarm.type}
-              disabled={!isAlarmFeatureEnabled}
-              onClick={() => handleOpenTimeModal(alarm.type, alarm.time)}
-              className={clsx(
-                "flex w-full items-center justify-between",
-                !isAlarmFeatureEnabled && "cursor-not-allowed",
-              )}
-            >
-              <span>
-                {alarm.type === "breakfast"
-                  ? "아침 알림"
-                  : alarm.type === "lunch"
-                    ? "점심 알림"
-                    : "저녁 알림"}
-              </span>
-
-              <div className="flex items-center gap-4">
-                <span
-                  className={
-                    isAlarmFeatureEnabled && alarm.enabled
-                      ? "text-brand-primary"
-                      : "text-font-extra-low"
-                  }
-                >
-                  {isAlarmFeatureEnabled && alarm.enabled ? alarm.time : "OFF"}
-                </span>
-                <ArrowIcon currentColor="#707070" />
-              </div>
-            </button>
-          ))}
+          {MEAL_ORDER.map((type) => {
+            const alarm = alerts[type];
+            return (
+              <button
+                key={type}
+                disabled={!masterEnabled}
+                onClick={() => handleOpenTimeModal(type, alarm.time)}
+                className={clsx(
+                  "flex w-full items-center justify-between",
+                  !masterEnabled && "cursor-not-allowed",
+                )}
+              >
+                <span>{MEAL_LABELS[type]}</span>
+                <div className="flex items-center gap-4">
+                  <span
+                    className={
+                      masterEnabled && alarm.enabled
+                        ? "text-brand-primary"
+                        : "text-font-extra-low"
+                    }
+                  >
+                    {masterEnabled && alarm.enabled ? alarm.time : "OFF"}
+                  </span>
+                  <ArrowIcon currentColor="#707070" />
+                </div>
+              </button>
+            );
+          })}
         </section>
       </main>
+
       {isTimeModalOpen && (
         <ModalWrapper>
           <TimePickerModal
@@ -130,6 +186,9 @@ export default function AlarmSettingPage() {
             onChangeTime={setTempTime}
             onConfirm={handleConfirmTime}
             onCancel={handleCloseModal}
+            onOff={handleTurnOff}
+            min={activeAlert?.min}
+            max={activeAlert?.max}
           />
         </ModalWrapper>
       )}

--- a/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
@@ -10,6 +10,7 @@ import { format } from "date-fns";
 
 import {
   getMukburimStatistics,
+  MUKBURIM_ERROR_CODE,
   type GetMukburimStatisticsResponse,
   type MukburimPeriod,
   type MukburimSortBy,
@@ -80,8 +81,8 @@ export default function MukburimLogPage() {
           const { status, data } = error.response ?? {};
           const code = data?.error?.errorCode;
           if (
-            (status === 404 && code === "MK001") ||
-            (status === 500 && code === "MK005")
+            (status === 404 && code === MUKBURIM_ERROR_CODE.NOT_FOUND) ||
+            (status === 500 && code === MUKBURIM_ERROR_CODE.STATISTICS_FAILED)
           ) {
             return data as GetMukburimStatisticsResponse;
           }

--- a/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
@@ -5,11 +5,12 @@ import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { useQuery } from "@tanstack/react-query";
-import clsx from "clsx";
+import { isAxiosError } from "axios";
 import { format } from "date-fns";
 
 import {
   getMukburimStatistics,
+  type GetMukburimStatisticsResponse,
   type MukburimPeriod,
   type MukburimSortBy,
 } from "@/entities/mukburim";
@@ -31,7 +32,7 @@ const SORT_ORDER_MAP: Record<SortOrder, MukburimSortBy> = {
 };
 
 const periodToApiPeriod = (period: Period): MukburimPeriod | undefined => {
-  if (period === "직접입력") return undefined;
+  if (period === "전체" || period === "직접입력") return undefined;
   return period as MukburimPeriod;
 };
 
@@ -71,7 +72,23 @@ export default function MukburimLogPage() {
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["mukburim-statistics", apiParams],
-    queryFn: () => getMukburimStatistics(apiParams),
+    queryFn: async () => {
+      try {
+        return await getMukburimStatistics(apiParams);
+      } catch (error) {
+        if (isAxiosError(error)) {
+          const { status, data } = error.response ?? {};
+          const code = data?.error?.errorCode;
+          if (
+            (status === 404 && code === "MK001") ||
+            (status === 500 && code === "MK005")
+          ) {
+            return data as GetMukburimStatisticsResponse;
+          }
+        }
+        throw error;
+      }
+    },
     staleTime: 1000 * 60 * 5,
   });
 

--- a/omechu-app/src/entities/alarm/api/mealAlertApi.ts
+++ b/omechu-app/src/entities/alarm/api/mealAlertApi.ts
@@ -1,0 +1,32 @@
+import type {
+  MealAlertPatchBody,
+  MealAlertsResponse,
+  MealAlertToggleResponse,
+} from "@/entities/alarm/model/alarm.types";
+import { axiosInstance } from "@/shared";
+
+export const getMealAlerts = async (): Promise<MealAlertsResponse> => {
+  const { data } =
+    await axiosInstance.get<MealAlertsResponse>("/user/meal-alerts");
+  return data;
+};
+
+export const patchMealAlerts = async (
+  body: MealAlertPatchBody,
+): Promise<MealAlertsResponse> => {
+  const { data } = await axiosInstance.patch<MealAlertsResponse>(
+    "/user/meal-alerts",
+    body,
+  );
+  return data;
+};
+
+export const toggleMealAlerts = async (
+  enabled: boolean,
+): Promise<MealAlertToggleResponse> => {
+  const { data } = await axiosInstance.post<MealAlertToggleResponse>(
+    "/user/meal-alerts/toggle",
+    { enabled },
+  );
+  return data;
+};

--- a/omechu-app/src/entities/alarm/index.ts
+++ b/omechu-app/src/entities/alarm/index.ts
@@ -1,0 +1,12 @@
+export {
+  getMealAlerts,
+  patchMealAlerts,
+  toggleMealAlerts,
+} from "./api/mealAlertApi";
+export type {
+  MealType,
+  MealAlertItem,
+  MealAlertsResponse,
+  MealAlertToggleResponse,
+  MealAlertPatchBody,
+} from "./model/alarm.types";

--- a/omechu-app/src/entities/alarm/model/alarm.types.ts
+++ b/omechu-app/src/entities/alarm/model/alarm.types.ts
@@ -1,0 +1,27 @@
+export type MealType = "breakfast" | "lunch" | "dinner" | "night";
+
+export interface MealAlertItem {
+  enabled: boolean;
+  time: string;
+  min: string;
+  max: string;
+}
+
+export interface MealAlertsResponse {
+  resultType: "SUCCESS" | "FAIL";
+  error: { errorCode: string; reason: string; data: unknown } | null;
+  success: {
+    enabled: boolean;
+    alerts: Record<MealType, MealAlertItem>;
+  } | null;
+}
+
+export interface MealAlertToggleResponse {
+  resultType: "SUCCESS" | "FAIL";
+  error: { errorCode: string; reason: string; data: unknown } | null;
+  success: { enabled: boolean } | null;
+}
+
+export type MealAlertPatchBody = Partial<
+  Record<MealType, { enabled?: boolean; time?: string }>
+>;

--- a/omechu-app/src/entities/alarm/model/alarm.types.ts
+++ b/omechu-app/src/entities/alarm/model/alarm.types.ts
@@ -10,10 +10,7 @@ export interface MealAlertItem {
 export interface MealAlertsResponse {
   resultType: "SUCCESS" | "FAIL";
   error: { errorCode: string; reason: string; data: unknown } | null;
-  success: {
-    enabled: boolean;
-    alerts: Record<MealType, MealAlertItem>;
-  } | null;
+  success: Record<MealType, MealAlertItem> | null;
 }
 
 export interface MealAlertToggleResponse {

--- a/omechu-app/src/entities/mukburim/config/mukburim.ts
+++ b/omechu-app/src/entities/mukburim/config/mukburim.ts
@@ -1,3 +1,8 @@
+export const MUKBURIM_ERROR_CODE = {
+  NOT_FOUND: "MK001",
+  STATISTICS_FAILED: "MK005",
+} as const;
+
 export type mukburimResponse = {
   resultType: string;
   error: null;

--- a/omechu-app/src/entities/mukburim/index.ts
+++ b/omechu-app/src/entities/mukburim/index.ts
@@ -5,6 +5,7 @@ export {
   getMukburimByDate,
 } from "./api/mukburimApi";
 export { usePostMukburim } from "./model/usePostMukburim";
+export { MUKBURIM_ERROR_CODE } from "./config/mukburim";
 export type { mukburimResponse } from "./config/mukburim";
 export type {
   MukburimPeriod,

--- a/omechu-app/src/widgets/mypage/ui/SetAlarmSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/SetAlarmSection.tsx
@@ -18,7 +18,10 @@ export function SetAlarmSection() {
     refetchOnWindowFocus: false,
   });
 
-  const isAlarmOn = data?.success?.enabled ?? false;
+  const alerts = data?.success;
+  const isAlarmOn = alerts
+    ? Object.values(alerts).some((a) => a.enabled)
+    : false;
 
   return (
     <section

--- a/omechu-app/src/widgets/mypage/ui/SetAlarmSection.tsx
+++ b/omechu-app/src/widgets/mypage/ui/SetAlarmSection.tsx
@@ -1,20 +1,24 @@
-//! 26.01.12 작업 중
-// TODO : onClick 수정
-
 "use client";
-
-import { useState } from "react";
 
 import { useRouter } from "next/navigation";
 
+import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
 
+import { getMealAlerts } from "@/entities/alarm";
 import { ArrowIcon } from "@/shared/assets/icons/index";
 
 export function SetAlarmSection() {
   const router = useRouter();
 
-  const [isAlarmOn, setIsAlarmOn] = useState(true);
+  const { data } = useQuery({
+    queryKey: ["user", "meal-alerts"],
+    queryFn: getMealAlerts,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  const isAlarmOn = data?.success?.enabled ?? false;
 
   return (
     <section

--- a/omechu-app/src/widgets/mypage/ui/TimePickerModal.tsx
+++ b/omechu-app/src/widgets/mypage/ui/TimePickerModal.tsx
@@ -6,6 +6,9 @@ type TimePickerModalProps = {
   onChangeTime: (time: string) => void;
   onConfirm: () => void;
   onCancel: () => void;
+  onOff?: () => void;
+  min?: string;
+  max?: string;
 };
 
 export const TimePickerModal = ({
@@ -14,6 +17,9 @@ export const TimePickerModal = ({
   onChangeTime,
   onConfirm,
   onCancel,
+  onOff,
+  min,
+  max,
 }: TimePickerModalProps) => {
   if (!open) return null;
 
@@ -22,15 +28,17 @@ export const TimePickerModal = ({
       <BaseModal
         title="알림 시간 정하기"
         isCloseButtonShow={false}
-        leftButtonText="취소"
+        leftButtonText={onOff ? "알림 끄기" : "취소"}
         rightButtonText="확인"
-        onLeftButtonClick={onCancel}
+        onLeftButtonClick={onOff ?? onCancel}
         onRightButtonClick={onConfirm}
       >
         <div className="mt-4 flex w-full justify-center">
           <input
             type="time"
             value={time}
+            min={min}
+            max={max}
             onChange={(e) => onChangeTime(e.target.value)}
             className="border-font-disabled text-body-2-regular w-2/3 rounded-[10px] border px-5 py-2"
           />


### PR DESCRIPTION
closed #308 

## 🔀 Pull Request Title

FIX: 알림 설정 페이지 API 연동 및 QA 버그 수정

<br>

## 📌 PR 설명

알림 설정 페이지의 useState 기반 로컬 상태를 React Query 서버 상태로 전환하고, QA에서 발견된 버그 3건을 수정했습니다.

- [x] 페이지 이탈 후 재진입 시 상태 초기화 버그 수정 (서버 데이터 조회로 전환)
- [x] 마스터 토글 OFF→ON 시 개별 알림 상태 유실 버그 수정 (별도 toggle API 사용)
- [x] 시간 설정 모달에서 개별 알림 OFF 설정 불가 버그 수정 (알림 끄기 버튼 추가)
- [x] 야식(night) 알림 항목 추가
- [x] alarm entity 신규 생성 (타입, API, barrel export)
- [x] SetAlarmSection 하드코딩 제거, 서버 상태 반영

<br>

## 📷 스크린샷
- QA #40
<img width="329" height="636" alt="image" src="https://github.com/user-attachments/assets/f9387090-ffa8-4036-8d29-d716d5df75c7" />

- QA #41
https://github.com/user-attachments/assets/e432637f-1388-443c-880c-48ea031ded5f


<br>

## 🔍 추가 설명

- `GET /user/meal-alerts`, `PATCH /user/meal-alerts`, `POST /user/meal-alerts/toggle` 3개 API를 연동했습니다.
- 마스터 토글은 별도 엔드포인트(`/toggle`)를 사용하여 서버에서 개별 알림 상태를 보존합니다.
- TimePickerModal에 `onOff`, `min`, `max` prop을 추가하여 기존 사용처에 영향 없이 기능을 확장했습니다.
- SetAlarmSection과 AlarmSettingPage가 동일한 queryKey(`["user", "meal-alerts"]`)를 공유하여 캐시를 통해 상태가 동기화됩니다.