### PR TITLE
[FIX] 비밀번호 변경 페이지 QA 수정

### DIFF
--- a/omechu-app/src/app/(private)/mypage/(settings)/account-setting/change-password/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/account-setting/change-password/page.tsx
@@ -91,7 +91,9 @@ export default function ChangePasswordPage() {
         : "error";
 
   const newPasswordHelperState =
-    newPasswordBlurred && newPassword.length > 0 && hasPasswordError(newPassword)
+    newPasswordBlurred &&
+    newPassword.length > 0 &&
+    hasPasswordError(newPassword)
       ? "error"
       : "default";
 

--- a/omechu-app/src/app/(private)/mypage/(settings)/account-setting/change-password/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/account-setting/change-password/page.tsx
@@ -24,6 +24,7 @@ export default function ChangePasswordPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isPending, setIsPending] = useState(false);
 
+  const [newPasswordBlurred, setNewPasswordBlurred] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
   const [showToast, setShowToast] = useState(false);
 
@@ -98,7 +99,7 @@ export default function ChangePasswordPage() {
       />
 
       <main className="relative mt-12 flex h-[80dvh] w-full flex-col items-center justify-between gap-8 px-6">
-        <section className="flex w-full flex-col gap-5">
+        <section className="flex w-fit flex-col gap-5">
           <FormField label="기존 비밀번호" id="current-password">
             <Input
               type="password"
@@ -112,12 +113,20 @@ export default function ChangePasswordPage() {
             label="새 비밀번호"
             id="new-password"
             helperText="* 대소문자, 숫자 및 특수문자 포함 8자 이상"
+            helperState={
+              newPasswordBlurred &&
+              newPassword.length > 0 &&
+              hasPasswordError(newPassword)
+                ? "error"
+                : "default"
+            }
           >
             <Input
               type="password"
               placeholder="새 비밀번호를 입력해주세요"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
+              onBlur={() => setNewPasswordBlurred(true)}
             />
           </FormField>
 

--- a/omechu-app/src/app/(private)/mypage/(settings)/account-setting/change-password/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/account-setting/change-password/page.tsx
@@ -90,6 +90,11 @@ export default function ChangePasswordPage() {
         ? "success"
         : "error";
 
+  const newPasswordHelperState =
+    newPasswordBlurred && newPassword.length > 0 && hasPasswordError(newPassword)
+      ? "error"
+      : "default";
+
   return (
     <>
       <Header
@@ -113,13 +118,7 @@ export default function ChangePasswordPage() {
             label="새 비밀번호"
             id="new-password"
             helperText="* 대소문자, 숫자 및 특수문자 포함 8자 이상"
-            helperState={
-              newPasswordBlurred &&
-              newPassword.length > 0 &&
-              hasPasswordError(newPassword)
-                ? "error"
-                : "default"
-            }
+            helperState={newPasswordHelperState}
           >
             <Input
               type="password"

--- a/omechu-app/src/shared/ui/input/Input.tsx
+++ b/omechu-app/src/shared/ui/input/Input.tsx
@@ -75,7 +75,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
           placeholder={placeholder}
           disabled={disabled}
           autoComplete="off"
-          className="w-full bg-transparent pr-8 outline-none"
+          className="w-full bg-transparent pr-8 outline-none [&::-ms-reveal]:hidden [&::-webkit-credentials-auto-fill-button]:hidden"
           value={props.value}
           onChange={props.onChange}
           {...props}


### PR DESCRIPTION
<br>

## 📌 PR 설명

- [x] PasswordInput 네이티브 reveal 버튼 숨김 처리 (Edge의 `ms-reveal`, Safari의 `credentials-auto-fill-button`)로 보기 버튼 중복 제거
- [x] 새 비밀번호 필드 blur 시 유효성 검사 실패 메시지를 빨간색으로 강조 (`helperState` 동적 설정)
- [x] section 너비를 `w-fit`으로 변경하여 레이아웃 정리

<br>

## 📷 스크린샷

https://github.com/user-attachments/assets/33eba3fb-2f6d-4bb1-92d5-2181749059ae


<br>

## 🔍 추가 설명

- 기존 비밀번호 일치 검증은 별도 API가 없어 서버 측 검증(400 에러 시 Toast 표시) 방식을 유지합니다.
- `next-env.d.ts`는 Next.js 자동 생성 파일이므로 커밋에서 제외했습니다.