### PR TITLE
[FIX] 이메일 문의 페이지 API 연동

### DIFF
--- a/omechu-app/src/app/(private)/mypage/(settings)/email-inquiry/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/email-inquiry/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { useRouter } from "next/navigation";
 
+import { ApiClientError, submitInquiry } from "@/entities/user";
 import { Button, FormField, Header, Input } from "@/shared";
 import { Toast } from "@/shared/ui/toast/Toast";
 
@@ -13,16 +14,42 @@ export default function EmailInquiryPage() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+  const [toastState, setToastState] = useState<"success" | "error">("success");
+  const [isPending, setIsPending] = useState(false);
 
-  const handleSubmit = () => {
-    if (!title || !content) return;
+  const handleSubmit = async () => {
+    if (!title || !content || isPending) return;
 
-    setShowToast(true);
+    setIsPending(true);
 
-    setTimeout(() => {
-      setShowToast(false);
-      router.back();
-    }, 3000);
+    try {
+      await submitInquiry({ title, content });
+
+      setToastMessage("문의가 정상적으로 접수되었습니다.");
+      setToastState("success");
+      setShowToast(true);
+
+      setTimeout(() => {
+        setShowToast(false);
+        router.back();
+      }, 3000);
+    } catch (error) {
+      const message =
+        error instanceof ApiClientError
+          ? error.message
+          : "문의 접수에 실패했습니다. 다시 시도해주세요.";
+
+      setToastMessage(message);
+      setToastState("error");
+      setShowToast(true);
+
+      setTimeout(() => {
+        setShowToast(false);
+      }, 3000);
+    } finally {
+      setIsPending(false);
+    }
   };
 
   return (
@@ -53,8 +80,11 @@ export default function EmailInquiryPage() {
             onChange={(e) => setContent(e.target.value)}
           />
         </FormField>
-        <Button disabled={!title || !content} onClick={handleSubmit}>
-          접수하기
+        <Button
+          disabled={!title || !content || isPending}
+          onClick={handleSubmit}
+        >
+          {isPending ? "접수 중..." : "접수하기"}
         </Button>
 
         <section className="text-font-extra-low bg-brand-tertiary text-caption-1-medium flex h-20 w-83.5 items-center justify-center rounded-[10px] whitespace-pre-line">
@@ -63,8 +93,8 @@ export default function EmailInquiryPage() {
       </main>
 
       <Toast
-        message={"문의가 정상적으로 접수되었습니다."}
-        state="success"
+        message={toastMessage}
+        state={toastState}
         show={showToast}
         className="bottom-10"
       />

--- a/omechu-app/src/app/(private)/mypage/(settings)/email-inquiry/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/(settings)/email-inquiry/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -29,11 +29,6 @@ export default function EmailInquiryPage() {
       setToastMessage("문의가 정상적으로 접수되었습니다.");
       setToastState("success");
       setShowToast(true);
-
-      setTimeout(() => {
-        setShowToast(false);
-        router.back();
-      }, 3000);
     } catch (error) {
       const message =
         error instanceof ApiClientError
@@ -43,14 +38,23 @@ export default function EmailInquiryPage() {
       setToastMessage(message);
       setToastState("error");
       setShowToast(true);
-
-      setTimeout(() => {
-        setShowToast(false);
-      }, 3000);
     } finally {
       setIsPending(false);
     }
   };
+
+  useEffect(() => {
+    if (!showToast) return;
+
+    const timer = setTimeout(() => {
+      setShowToast(false);
+      if (toastState === "success") {
+        router.back();
+      }
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [showToast, toastState, router]);
 
   return (
     <>

--- a/omechu-app/src/entities/user/api/profileApi.ts
+++ b/omechu-app/src/entities/user/api/profileApi.ts
@@ -2,6 +2,8 @@ import axios from "axios";
 
 import { ApiClientError } from "@/entities/user/api/authApi";
 import type {
+  InquiryRequestBody,
+  InquiryResponse,
   ProfileType,
   UpdateProfileBody,
   WithdrawRequestBody,
@@ -118,6 +120,43 @@ export async function withdrawAccount(
       const api = error.response?.data as ApiResponse<unknown> | undefined;
       throw new ApiClientError(
         api?.error?.reason ?? error.message ?? "회원 탈퇴에 실패했습니다.",
+        api?.error?.errorCode,
+        error.response?.status,
+        api?.error?.data,
+      );
+    }
+
+    throw new ApiClientError("알 수 없는 오류가 발생했습니다.");
+  }
+}
+
+export async function submitInquiry(
+  data: InquiryRequestBody,
+): Promise<InquiryResponse> {
+  try {
+    const res = await axiosInstance.post<ApiResponse<InquiryResponse>>(
+      "/user/inquiry",
+      data,
+    );
+
+    const apiResponse = res.data;
+    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
+      throw new ApiClientError(
+        apiResponse.error?.reason ?? "문의 접수에 실패했습니다.",
+        apiResponse.error?.errorCode,
+        res.status,
+        apiResponse.error?.data,
+      );
+    }
+
+    return apiResponse.success;
+  } catch (error: unknown) {
+    if (error instanceof ApiClientError) throw error;
+
+    if (axios.isAxiosError(error)) {
+      const api = error.response?.data as ApiResponse<unknown> | undefined;
+      throw new ApiClientError(
+        api?.error?.reason ?? error.message ?? "문의 접수에 실패했습니다.",
         api?.error?.errorCode,
         error.response?.status,
         api?.error?.data,

--- a/omechu-app/src/entities/user/api/profileApi.ts
+++ b/omechu-app/src/entities/user/api/profileApi.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { type AxiosResponse } from "axios";
 
 import { ApiClientError } from "@/entities/user/api/authApi";
 import type {
@@ -12,157 +12,74 @@ import type {
 import type { ApiResponse } from "@/shared/config/api.types";
 import { axiosInstance } from "@/shared/lib/axiosInstance";
 
-export class ProfileApiError extends Error {
-  constructor(
-    public code: number,
-    public info?: unknown,
-  ) {
-    super("Profile API Error");
-    this.name = "ProfileApiError";
-  }
-}
-
-export async function fetchProfile(): Promise<ProfileType> {
+async function handleApiResponse<T>(
+  request: Promise<AxiosResponse<ApiResponse<T>>>,
+  fallbackMessage: string,
+): Promise<T> {
   try {
-    const res = await axiosInstance.get<ApiResponse<ProfileType>>(
-      "/user/profile",
-      {
-        validateStatus: (s) => s === 200,
-        timeout: 5000,
-      },
-    );
-
+    const res = await request;
     const apiResponse = res.data;
+
     if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
-      throw new ProfileApiError(
+      throw new ApiClientError(
+        apiResponse.error?.reason ?? fallbackMessage,
+        apiResponse.error?.errorCode,
         res.status,
-        apiResponse.error?.reason ?? "프로필 조회에 실패했습니다.",
+        apiResponse.error?.data,
       );
     }
 
     return apiResponse.success;
   } catch (error: unknown) {
-    if (error instanceof ProfileApiError) throw error;
+    if (error instanceof ApiClientError) throw error;
 
     if (axios.isAxiosError(error)) {
-      const status = error.response?.status ?? 500;
-      const reason =
-        (error.response?.data as ApiResponse<unknown>)?.error?.reason ??
-        error.message;
-      throw new ProfileApiError(status, reason);
+      const api = error.response?.data as ApiResponse<unknown> | undefined;
+      throw new ApiClientError(
+        api?.error?.reason ?? error.message ?? fallbackMessage,
+        api?.error?.errorCode,
+        error.response?.status,
+        api?.error?.data,
+      );
     }
 
-    throw new ProfileApiError(500, "알 수 없는 오류가 발생했습니다.");
+    throw new ApiClientError("알 수 없는 오류가 발생했습니다.");
   }
+}
+
+export async function fetchProfile(): Promise<ProfileType> {
+  return handleApiResponse(
+    axiosInstance.get<ApiResponse<ProfileType>>("/user/profile", {
+      validateStatus: (s) => s === 200,
+      timeout: 5000,
+    }),
+    "프로필 조회에 실패했습니다.",
+  );
 }
 
 export async function updateProfile(
   data: UpdateProfileBody,
 ): Promise<ProfileType> {
-  try {
-    const res = await axiosInstance.patch<ApiResponse<ProfileType>>(
-      "/user/profile",
-      data,
-    );
-
-    const apiResponse = res.data;
-    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
-      throw new ApiClientError(
-        apiResponse.error?.reason ?? "프로필 수정에 실패했습니다.",
-        apiResponse.error?.errorCode,
-        res.status,
-        apiResponse.error?.data,
-      );
-    }
-
-    return apiResponse.success;
-  } catch (error: unknown) {
-    if (error instanceof ApiClientError) throw error;
-
-    if (axios.isAxiosError(error)) {
-      const api = error.response?.data as ApiResponse<unknown> | undefined;
-      throw new ApiClientError(
-        api?.error?.reason ?? error.message ?? "프로필 수정에 실패했습니다.",
-        api?.error?.errorCode,
-        error.response?.status,
-        api?.error?.data,
-      );
-    }
-
-    throw new ApiClientError("알 수 없는 오류가 발생했습니다.");
-  }
+  return handleApiResponse(
+    axiosInstance.patch<ApiResponse<ProfileType>>("/user/profile", data),
+    "프로필 수정에 실패했습니다.",
+  );
 }
 
 export async function withdrawAccount(
   data: WithdrawRequestBody,
 ): Promise<WithdrawResponse> {
-  try {
-    const res = await axiosInstance.post<ApiResponse<WithdrawResponse>>(
-      "/user/withdraw",
-      data,
-    );
-
-    const apiResponse = res.data;
-    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
-      throw new ApiClientError(
-        apiResponse.error?.reason ?? "회원 탈퇴에 실패했습니다.",
-        apiResponse.error?.errorCode,
-        res.status,
-        apiResponse.error?.data,
-      );
-    }
-
-    return apiResponse.success;
-  } catch (error: unknown) {
-    if (error instanceof ApiClientError) throw error;
-
-    if (axios.isAxiosError(error)) {
-      const api = error.response?.data as ApiResponse<unknown> | undefined;
-      throw new ApiClientError(
-        api?.error?.reason ?? error.message ?? "회원 탈퇴에 실패했습니다.",
-        api?.error?.errorCode,
-        error.response?.status,
-        api?.error?.data,
-      );
-    }
-
-    throw new ApiClientError("알 수 없는 오류가 발생했습니다.");
-  }
+  return handleApiResponse(
+    axiosInstance.post<ApiResponse<WithdrawResponse>>("/user/withdraw", data),
+    "회원 탈퇴에 실패했습니다.",
+  );
 }
 
 export async function submitInquiry(
   data: InquiryRequestBody,
 ): Promise<InquiryResponse> {
-  try {
-    const res = await axiosInstance.post<ApiResponse<InquiryResponse>>(
-      "/user/inquiry",
-      data,
-    );
-
-    const apiResponse = res.data;
-    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
-      throw new ApiClientError(
-        apiResponse.error?.reason ?? "문의 접수에 실패했습니다.",
-        apiResponse.error?.errorCode,
-        res.status,
-        apiResponse.error?.data,
-      );
-    }
-
-    return apiResponse.success;
-  } catch (error: unknown) {
-    if (error instanceof ApiClientError) throw error;
-
-    if (axios.isAxiosError(error)) {
-      const api = error.response?.data as ApiResponse<unknown> | undefined;
-      throw new ApiClientError(
-        api?.error?.reason ?? error.message ?? "문의 접수에 실패했습니다.",
-        api?.error?.errorCode,
-        error.response?.status,
-        api?.error?.data,
-      );
-    }
-
-    throw new ApiClientError("알 수 없는 오류가 발생했습니다.");
-  }
+  return handleApiResponse(
+    axiosInstance.post<ApiResponse<InquiryResponse>>("/user/inquiry", data),
+    "문의 접수에 실패했습니다.",
+  );
 }

--- a/omechu-app/src/entities/user/index.ts
+++ b/omechu-app/src/entities/user/index.ts
@@ -24,7 +24,6 @@ export {
 } from "./api/authApi";
 
 export {
-  ProfileApiError,
   fetchProfile,
   updateProfile,
   withdrawAccount,

--- a/omechu-app/src/entities/user/index.ts
+++ b/omechu-app/src/entities/user/index.ts
@@ -28,6 +28,7 @@ export {
   fetchProfile,
   updateProfile,
   withdrawAccount,
+  submitInquiry,
 } from "./api/profileApi";
 
 export {
@@ -72,6 +73,8 @@ export type {
   UpdateProfileBody,
   WithdrawRequestBody,
   WithdrawResponse,
+  InquiryRequestBody,
+  InquiryResponse,
   ExerciseType,
   PreferType,
   AllergyType,

--- a/omechu-app/src/entities/user/model/profile.types.ts
+++ b/omechu-app/src/entities/user/model/profile.types.ts
@@ -48,3 +48,13 @@ export interface WithdrawResponse {
   success: boolean;
   message: string;
 }
+
+export interface InquiryRequestBody {
+  title: string;
+  content: string;
+}
+
+export interface InquiryResponse {
+  success: boolean;
+  message: string;
+}


### PR DESCRIPTION
## 📌 PR 설명

이메일 문의 페이지에서 실제 API 호출 없이 토스트만 표시되던 버그를 수정했습니다.

- [x] `POST /user/inquiry` 엔드포인트 연동 (`submitInquiry` API 함수 추가)
- [x] `InquiryRequestBody`, `InquiryResponse` 타입 정의 및 barrel export
- [x] 중복 제출 방지를 위한 `isPending` 상태 처리
- [x] 성공/실패에 따른 토스트 메시지 분기 처리

<br>

## 📷 스크린샷

Uploading 화면 기록 2026-02-15 오전 6.58.23.mov…



<br>

## 🔍 추가 설명

- 기존 `withdrawAccount` 함수와 동일한 패턴(POST + ApiClientError)으로 작성
- 접수 중 버튼 텍스트가 "접수 중..."으로 변경되며 비활성화 처리