### PR TITLE
[FEAT] 추천 목록 관리 페이지 API 연동

### DIFF
--- a/omechu-app/src/app/(private)/mypage/recommended-list/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/recommended-list/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
+import {
+  useRecommendManagement,
+  useExceptMenuMutation,
+  useRemoveExceptMenuMutation,
+} from "@/entities/user";
 import { MENU_SUGGESTIONS } from "@/shared/constants/mypage";
 import { Header, SearchBar } from "@/shared/index";
 import {
@@ -14,35 +19,38 @@ import {
 
 export default function RecommendedListPage() {
   const router = useRouter();
-
   const mainRef = useRef<HTMLDivElement>(null);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
-  const [excludedSet, setExcludedSet] = useState<Set<number>>(new Set());
+
+  const { data, isLoading } = useRecommendManagement();
+  const exceptMutation = useExceptMenuMutation();
+  const removeExceptMutation = useRemoveExceptMenuMutation();
+
+  const currentMenus = useMemo(() => {
+    const menus =
+      selectedIndex === 0
+        ? (data?.recommendMenus ?? [])
+        : (data?.exceptedMenus ?? []);
+
+    if (!searchTerm.trim()) return menus;
+
+    const term = searchTerm.trim().toLowerCase();
+    return menus.filter((menu) => menu.name.toLowerCase().includes(term));
+  }, [data, selectedIndex, searchTerm]);
+
+  const handleToggle = (menuId: string) => {
+    if (selectedIndex === 0) {
+      exceptMutation.mutate({ menuId });
+    } else {
+      removeExceptMutation.mutate({ menuId });
+    }
+  };
 
   const handleSearch = (term: string) => {
     setSearchTerm(term);
-    console.log("검색 실행:", term);
   };
-
-  const toggleExclude = (index: number) => {
-    setExcludedSet((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
-      } else {
-        next.add(index);
-      }
-      return next;
-    });
-  };
-
-  const allItems = Array.from({ length: 30 }).map((_, i) => i);
-
-  const filteredItems = allItems.filter((i) =>
-    selectedIndex === 0 ? !excludedSet.has(i) : excludedSet.has(i),
-  );
 
   const scrollToTop = () => {
     if (mainRef.current) {
@@ -75,17 +83,31 @@ export default function RecommendedListPage() {
           suggestionList={MENU_SUGGESTIONS}
         />
 
-        <section className="grid w-84 grid-cols-3 gap-3 pb-15">
-          {filteredItems.map((i) => (
-            <RecommendedFoodBox
-              key={i}
-              title={`타코 ${i}`}
-              src=""
-              onClick={() => toggleExclude(i)}
-              isToggled={excludedSet.has(i)}
-            />
-          ))}
-        </section>
+        {isLoading ? (
+          <div className="text-font-low flex h-40 items-center justify-center">
+            불러오는 중...
+          </div>
+        ) : currentMenus.length === 0 ? (
+          <div className="text-font-low flex h-40 items-center justify-center">
+            {searchTerm.trim()
+              ? "검색 결과가 없습니다."
+              : selectedIndex === 0
+                ? "추천 메뉴가 없습니다."
+                : "제외된 메뉴가 없습니다."}
+          </div>
+        ) : (
+          <section className="grid w-84 grid-cols-3 gap-3 pb-15">
+            {currentMenus.map((menu) => (
+              <RecommendedFoodBox
+                key={menu.id}
+                title={menu.name}
+                src={menu.image_link}
+                onClick={() => handleToggle(menu.id)}
+                isToggled={selectedIndex === 1}
+              />
+            ))}
+          </section>
+        )}
 
         <FloatingActionButton onClick={scrollToTop} />
       </main>

--- a/omechu-app/src/app/(private)/mypage/recommended-list/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/recommended-list/page.tsx
@@ -17,6 +17,11 @@ import {
   SelectTab,
 } from "@/widgets/mypage/ui";
 
+const TAB = {
+  RECOMMEND: 0,
+  EXCEPT: 1,
+} as const;
+
 export default function RecommendedListPage() {
   const router = useRouter();
   const mainRef = useRef<HTMLDivElement>(null);
@@ -30,7 +35,7 @@ export default function RecommendedListPage() {
 
   const currentMenus = useMemo(() => {
     const menus =
-      selectedIndex === 0
+      selectedIndex === TAB.RECOMMEND
         ? (data?.recommendMenus ?? [])
         : (data?.exceptedMenus ?? []);
 
@@ -41,7 +46,7 @@ export default function RecommendedListPage() {
   }, [data, selectedIndex, searchTerm]);
 
   const handleToggle = (menuId: string) => {
-    if (selectedIndex === 0) {
+    if (selectedIndex === TAB.RECOMMEND) {
       exceptMutation.mutate({ menuId });
     } else {
       removeExceptMutation.mutate({ menuId });
@@ -91,7 +96,7 @@ export default function RecommendedListPage() {
           <div className="text-font-low flex h-40 items-center justify-center">
             {searchTerm.trim()
               ? "검색 결과가 없습니다."
-              : selectedIndex === 0
+              : selectedIndex === TAB.RECOMMEND
                 ? "추천 메뉴가 없습니다."
                 : "제외된 메뉴가 없습니다."}
           </div>
@@ -103,7 +108,7 @@ export default function RecommendedListPage() {
                 title={menu.name}
                 src={menu.image_link}
                 onClick={() => handleToggle(menu.id)}
-                isToggled={selectedIndex === 1}
+                isToggled={selectedIndex === TAB.EXCEPT}
               />
             ))}
           </section>

--- a/omechu-app/src/entities/user/api/recommendApi.ts
+++ b/omechu-app/src/entities/user/api/recommendApi.ts
@@ -78,9 +78,10 @@ export async function removeExceptMenu(
   data: RemoveExceptMenuRequest,
 ): Promise<RemoveExceptMenuResponse> {
   try {
-    const res = await axiosInstance.post<
-      ApiResponse<RemoveExceptMenuResponse>
-    >("/user/recommend/except/remove", data);
+    const res = await axiosInstance.post<ApiResponse<RemoveExceptMenuResponse>>(
+      "/user/recommend/except/remove",
+      data,
+    );
 
     const apiResponse = res.data;
     if (apiResponse.resultType === "FAIL" || !apiResponse.success) {

--- a/omechu-app/src/entities/user/api/recommendApi.ts
+++ b/omechu-app/src/entities/user/api/recommendApi.ts
@@ -1,0 +1,99 @@
+import axios from "axios";
+
+import { ApiClientError } from "@/entities/user/api/authApi";
+import type {
+  ExceptMenuRequest,
+  ExceptMenuResponse,
+  RecommendManagementResponse,
+  RemoveExceptMenuRequest,
+  RemoveExceptMenuResponse,
+} from "@/entities/user/model/recommend.types";
+import type { ApiResponse } from "@/shared/config/api.types";
+import { axiosInstance } from "@/shared/lib/axiosInstance";
+
+function handleApiError(error: unknown, fallbackMessage: string): never {
+  if (error instanceof ApiClientError) throw error;
+
+  if (axios.isAxiosError(error)) {
+    const api = error.response?.data as ApiResponse<unknown> | undefined;
+    throw new ApiClientError(
+      api?.error?.reason ?? error.message ?? fallbackMessage,
+      api?.error?.errorCode,
+      error.response?.status,
+      api?.error?.data,
+    );
+  }
+
+  throw new ApiClientError(fallbackMessage);
+}
+
+export async function fetchRecommendManagement(): Promise<RecommendManagementResponse> {
+  try {
+    const res = await axiosInstance.get<
+      ApiResponse<RecommendManagementResponse>
+    >("/user/recommend/management");
+
+    const apiResponse = res.data;
+    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
+      throw new ApiClientError(
+        apiResponse.error?.reason ?? "추천 목록 조회에 실패했습니다.",
+        apiResponse.error?.errorCode,
+        res.status,
+        apiResponse.error?.data,
+      );
+    }
+
+    return apiResponse.success;
+  } catch (error: unknown) {
+    handleApiError(error, "추천 목록 조회에 실패했습니다.");
+  }
+}
+
+export async function exceptMenu(
+  data: ExceptMenuRequest,
+): Promise<ExceptMenuResponse> {
+  try {
+    const res = await axiosInstance.post<ApiResponse<ExceptMenuResponse>>(
+      "/user/recommend/except",
+      data,
+    );
+
+    const apiResponse = res.data;
+    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
+      throw new ApiClientError(
+        apiResponse.error?.reason ?? "메뉴 제외에 실패했습니다.",
+        apiResponse.error?.errorCode,
+        res.status,
+        apiResponse.error?.data,
+      );
+    }
+
+    return apiResponse.success;
+  } catch (error: unknown) {
+    handleApiError(error, "메뉴 제외에 실패했습니다.");
+  }
+}
+
+export async function removeExceptMenu(
+  data: RemoveExceptMenuRequest,
+): Promise<RemoveExceptMenuResponse> {
+  try {
+    const res = await axiosInstance.post<
+      ApiResponse<RemoveExceptMenuResponse>
+    >("/user/recommend/except/remove", data);
+
+    const apiResponse = res.data;
+    if (apiResponse.resultType === "FAIL" || !apiResponse.success) {
+      throw new ApiClientError(
+        apiResponse.error?.reason ?? "메뉴 제외 해제에 실패했습니다.",
+        apiResponse.error?.errorCode,
+        res.status,
+        apiResponse.error?.data,
+      );
+    }
+
+    return apiResponse.success;
+  } catch (error: unknown) {
+    handleApiError(error, "메뉴 제외 해제에 실패했습니다.");
+  }
+}

--- a/omechu-app/src/entities/user/index.ts
+++ b/omechu-app/src/entities/user/index.ts
@@ -31,6 +31,12 @@ export {
 } from "./api/profileApi";
 
 export {
+  fetchRecommendManagement,
+  exceptMenu,
+  removeExceptMenu,
+} from "./api/recommendApi";
+
+export {
   useLoginMutation,
   useSignupMutation,
   useLogoutMutation,
@@ -41,6 +47,12 @@ export {
 } from "./lib/hooks/useAuth";
 
 export { useProfile, useUpdateProfileMutation } from "./lib/hooks/useProfile";
+
+export {
+  useRecommendManagement,
+  useExceptMenuMutation,
+  useRemoveExceptMenuMutation,
+} from "./lib/hooks/useRecommendManagement";
 
 export { useKakaoLogin } from "./lib/hooks/useKakaoLogin";
 
@@ -76,3 +88,13 @@ export type {
   PreferType,
   AllergyType,
 } from "./model/profile.types";
+
+export type {
+  RecommendMenuItem,
+  RecommendManagementSummary,
+  RecommendManagementResponse,
+  ExceptMenuRequest,
+  ExceptMenuResponse,
+  RemoveExceptMenuRequest,
+  RemoveExceptMenuResponse,
+} from "./model/recommend.types";

--- a/omechu-app/src/entities/user/lib/hooks/useRecommendManagement.ts
+++ b/omechu-app/src/entities/user/lib/hooks/useRecommendManagement.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  exceptMenu,
+  fetchRecommendManagement,
+  removeExceptMenu,
+} from "@/entities/user/api/recommendApi";
+import { useAuthStore } from "@/entities/user/model/auth.store";
+import type {
+  ExceptMenuRequest,
+  RemoveExceptMenuRequest,
+} from "@/entities/user/model/recommend.types";
+
+const RECOMMEND_MANAGEMENT_KEY = ["user", "recommend", "management"] as const;
+
+export function useRecommendManagement() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  return useQuery({
+    queryKey: RECOMMEND_MANAGEMENT_KEY,
+    queryFn: fetchRecommendManagement,
+    enabled: !!accessToken,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useExceptMenuMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ExceptMenuRequest) => exceptMenu(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: RECOMMEND_MANAGEMENT_KEY });
+    },
+  });
+}
+
+export function useRemoveExceptMenuMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: RemoveExceptMenuRequest) => removeExceptMenu(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: RECOMMEND_MANAGEMENT_KEY });
+    },
+  });
+}

--- a/omechu-app/src/entities/user/model/recommend.types.ts
+++ b/omechu-app/src/entities/user/model/recommend.types.ts
@@ -1,0 +1,38 @@
+export interface RecommendMenuItem {
+  id: string;
+  name: string;
+  image_link: string;
+}
+
+export interface RecommendManagementSummary {
+  totalMenus: number;
+  recommendMenus: number;
+  exceptedMenus: number;
+}
+
+export interface RecommendManagementResponse {
+  summary: RecommendManagementSummary;
+  recommendMenus: RecommendMenuItem[];
+  exceptedMenus: RecommendMenuItem[];
+}
+
+export interface ExceptMenuRequest {
+  menuId?: string;
+  menuName?: string;
+}
+
+export interface ExceptMenuResponse {
+  id: string;
+  menu: RecommendMenuItem;
+  message: string;
+}
+
+export interface RemoveExceptMenuRequest {
+  menuId?: string;
+  menuName?: string;
+}
+
+export interface RemoveExceptMenuResponse {
+  success: boolean;
+  message: string;
+}


### PR DESCRIPTION
## PR 설명

추천 목록 관리 페이지(`recommended-list/page.tsx`)의 하드코딩된 데이터를 실제 API와 연동합니다.

- [x] 추천/제외 메뉴 관련 타입 정의 (`recommend.types.ts`)
- [x] API 함수 구현 (`recommendApi.ts`) - 조회, 제외, 복원
- [x] React Query 훅 구현 (`useRecommendManagement.ts`)
- [x] 페이지 리팩토링 - 서버 데이터 조회, 탭별 제외/복원 토글, 검색 필터링, 로딩/빈 상태 처리
- [x] barrel export 업데이트

---

## 스크린샷

API 서버 연동 후 확인 필요

---

## FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 추가 설명

- `profileApi.ts`의 에러 처리 패턴을 따라 `handleApiError` 헬퍼를 로컬로 구현
- mutation 성공 시 `invalidateQueries`로 목록 자동 리프레시
- `pnpm build`, `pnpm lint` 모두 에러 없이 통과