### PR TITLE
[FIX] 마이페이지 기본 정보 수정 후 캐시 미갱신 수정

### DIFF
--- a/omechu-app/src/app/(private)/mypage/basic-state/[step]/AllergyForm.tsx
+++ b/omechu-app/src/app/(private)/mypage/basic-state/[step]/AllergyForm.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 
 import { BasicAllergyForm, useOnboardingStore } from "@/entities/onboarding";
-import { updateProfile } from "@/entities/user/api/profileApi";
+import { useUpdateProfileMutation } from "@/entities/user";
 import type {
   AllergyType,
   ExerciseType,
@@ -13,9 +13,10 @@ import type {
 export default function AllergyForm() {
   const router = useRouter();
   const { exercise, prefer, allergy } = useOnboardingStore();
+  const { mutateAsync } = useUpdateProfileMutation();
 
   const handleSave = async () => {
-    await updateProfile({
+    await mutateAsync({
       exercise: (exercise ?? undefined) as ExerciseType | undefined,
       prefer: prefer as PreferType[],
       allergy: allergy.filter((a) => a !== "없음") as AllergyType[],


### PR DESCRIPTION
## Summary
- 마이페이지 기본 정보(운동 상태/선호 음식/알레르기) 수정 후 저장 시, React Query 캐시가 갱신되지 않아 변경된 값이 화면에 반영되지 않는 문제 수정
- `AllergyForm`에서 `updateProfile()` 직접 호출을 `useUpdateProfileMutation()` 훅으로 교체하여 캐시 + auth store 동기화

## Changes
- `updateProfile` 직접 import 제거
- `useUpdateProfileMutation` 훅 사용으로 변경
- 저장 시 `mutateAsync()`를 통해 `onSuccess` 콜백에서 자동으로 `setQueryData` + `setUser` 실행

## Test plan
- [x] 마이페이지 -> "다시 입력하기" -> 운동 상태 변경 -> 저장 -> "내 정보 보기" -> 변경된 값 표시 확인
- [x] 다시 "다시 입력하기" 진입 시 직전에 저장한 값으로 폼 초기화 확인
- [ ] PWA 환경에서 새로고침 없이 값 반영 확인