### PR TITLE
[FIX] 결과 페이지 공유 메타데이터 QA 반영

### DIFF
--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 
-import { generateSummaryMetadata } from "@/shared/lib/generateMenuMetadata";
-import { fetchRecommendMenuForMetadata } from "@/shared/lib/metadataFetchers";
+import { generateMenuMetadata } from "@/shared/lib/generateMenuMetadata";
+import { fetchMenuDetailForMetadata } from "@/shared/lib/metadataFetchers";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -15,30 +15,16 @@ export async function generateMetadata({
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
 
-    const recommendResponse =
-      await fetchRecommendMenuForMetadata(decodedMenuId);
+    const menuDetail = await fetchMenuDetailForMetadata(decodedMenuId);
 
-    if (!recommendResponse || recommendResponse.results.length === 0) {
-      return {
-        title: "맞춤 추천 | 오메추",
-        description: "오늘 뭐 먹지? 오메추에서 맞춤 메뉴를 추천받아보세요.",
-        robots: { index: false, follow: true },
-      };
-    }
-
-    const menuNames = recommendResponse.results.map((item) => item.menu);
-
-    return generateSummaryMetadata(
-      menuNames,
-      "맞춤 추천",
-      `/mainpage/result/${menuId}`,
-    );
+    return generateMenuMetadata(menuDetail, `/mainpage/result/${menuId}`);
   } catch (error) {
     console.error("Failed to generate metadata:", error);
 
     return {
-      title: "맞춤 추천 | 오메추",
-      description: "오늘 뭐 먹지? 오메추에서 맞춤 메뉴를 추천받아보세요.",
+      title: "오메추 | 오늘 뭐 먹지?",
+      description:
+        "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
       robots: { index: false, follow: true },
     };
   }

--- a/omechu-app/src/app/(public)/menu-battle/play/[id]/layout.tsx
+++ b/omechu-app/src/app/(public)/menu-battle/play/[id]/layout.tsx
@@ -27,6 +27,7 @@ export async function generateMetadata({
         title: "오메추 | 메뉴 배틀",
         description:
           "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
+        robots: { index: false, follow: true },
       };
     }
 
@@ -48,6 +49,7 @@ export async function generateMetadata({
       title: "오메추 | 메뉴 배틀",
       description:
         "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
+      robots: { index: false, follow: true },
     };
   }
 }

--- a/omechu-app/src/app/(public)/menu-battle/play/[id]/layout.tsx
+++ b/omechu-app/src/app/(public)/menu-battle/play/[id]/layout.tsx
@@ -33,10 +33,7 @@ export async function generateMetadata({
     const menuDetail = await fetchMenuDetailForMetadata(winner.menuName);
 
     if (menuDetail) {
-      return generateMenuMetadata(
-        menuDetail,
-        `/menu-battle/play/${battleId}`,
-      );
+      return generateMenuMetadata(menuDetail, `/menu-battle/play/${battleId}`);
     }
 
     return generateMinimalMetadata(

--- a/omechu-app/src/app/(public)/menu-battle/play/[id]/layout.tsx
+++ b/omechu-app/src/app/(public)/menu-battle/play/[id]/layout.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from "next";
+
+import {
+  generateMenuMetadata,
+  generateMinimalMetadata,
+} from "@/shared/lib/generateMenuMetadata";
+import {
+  fetchBattleWinnerForMetadata,
+  fetchMenuDetailForMetadata,
+} from "@/shared/lib/metadataFetchers";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: LayoutProps): Promise<Metadata> {
+  try {
+    const { id: battleId } = await params;
+
+    const winner = await fetchBattleWinnerForMetadata(battleId);
+
+    if (!winner) {
+      return {
+        title: "오메추 | 메뉴 배틀",
+        description:
+          "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
+      };
+    }
+
+    const menuDetail = await fetchMenuDetailForMetadata(winner.menuName);
+
+    if (menuDetail) {
+      return generateMenuMetadata(
+        menuDetail,
+        `/menu-battle/play/${battleId}`,
+      );
+    }
+
+    return generateMinimalMetadata(
+      winner.menuName,
+      winner.imageLink,
+      `/menu-battle/play/${battleId}`,
+    );
+  } catch (error) {
+    console.error("Failed to generate metadata:", error);
+
+    return {
+      title: "오메추 | 메뉴 배틀",
+      description:
+        "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
+    };
+  }
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return <>{children}</>;
+}

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/layout.tsx
@@ -7,12 +7,8 @@ import {
   generateMinimalMetadata,
   generateRecipeJsonLd,
 } from "@/shared/lib/generateMenuMetadata";
-import {
-  fetchMenuDetailForMetadata,
-  fetchRandomMenuForMetadata,
-} from "@/shared/lib/metadataFetchers";
+import { fetchMenuDetailForMetadata } from "@/shared/lib/metadataFetchers";
 
-const getCachedRandomMenu = cache(fetchRandomMenuForMetadata);
 const getCachedMenuDetail = cache(fetchMenuDetailForMetadata);
 
 interface LayoutProps {
@@ -27,37 +23,24 @@ export async function generateMetadata({
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
 
-    const randomMenu = await getCachedRandomMenu(decodedMenuId);
-
-    if (!randomMenu) {
-      return {
-        title: "랜덤 추천 | 오메추",
-        description: "오늘 뭐 먹지? 오메추에서 랜덤 메뉴를 추천받아보세요.",
-        robots: { index: false, follow: true },
-      };
-    }
-
-    const menuDetail = await getCachedMenuDetail(randomMenu.name);
+    const menuDetail = await getCachedMenuDetail(decodedMenuId);
 
     if (menuDetail) {
-      return generateMenuMetadata(
-        menuDetail,
-        "랜덤 추천",
-        `/random-recommend/${menuId}`,
-      );
-    } else {
-      return generateMinimalMetadata(
-        randomMenu,
-        "랜덤 추천",
-        `/random-recommend/${menuId}`,
-      );
+      return generateMenuMetadata(menuDetail, `/random-recommend/${menuId}`);
     }
+
+    return generateMinimalMetadata(
+      decodedMenuId,
+      null,
+      `/random-recommend/${menuId}`,
+    );
   } catch (error) {
     console.error("Failed to generate metadata:", error);
 
     return {
-      title: "랜덤 추천 | 오메추",
-      description: "오늘 뭐 먹지? 오메추에서 랜덤 메뉴를 추천받아보세요.",
+      title: "오메추 | 오늘 뭐 먹지?",
+      description:
+        "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
       robots: { index: false, follow: true },
     };
   }
@@ -70,14 +53,10 @@ export default async function Layout({ children, params }: LayoutProps) {
     const { menuId } = await params;
     const decodedMenuId = decodeURIComponent(menuId);
 
-    const randomMenu = await getCachedRandomMenu(decodedMenuId);
+    const menuDetail = await getCachedMenuDetail(decodedMenuId);
 
-    if (randomMenu) {
-      const menuDetail = await getCachedMenuDetail(randomMenu.name);
-
-      if (menuDetail) {
-        jsonLd = generateRecipeJsonLd(menuDetail);
-      }
+    if (menuDetail) {
+      jsonLd = generateRecipeJsonLd(menuDetail);
     }
   } catch (error) {
     console.error("Failed to generate JSON-LD:", error);

--- a/omechu-app/src/shared/lib/generateMenuMetadata.ts
+++ b/omechu-app/src/shared/lib/generateMenuMetadata.ts
@@ -7,40 +7,28 @@ const MAX_DISPLAY_MENUS = 5;
 
 export function generateMenuMetadata(
   menuDetail: MenuDetail | null,
-  pageType: "랜덤 추천" | "맞춤 추천",
   currentPath: string,
 ): Metadata {
   if (!menuDetail) {
     return {
-      title: `${pageType} | 오메추`,
-      description: "오늘 뭐 먹지? 오메추에서 메뉴를 추천받아보세요.",
+      title: "오메추 | 오늘 뭐 먹지?",
+      description:
+        "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?",
       robots: { index: false, follow: true },
     };
   }
 
-  const { name, description, image_link, allergic, calory, protein } =
-    menuDetail;
+  const { name, image_link } = menuDetail;
 
-  const title = `${name} ${pageType}`;
-
-  const metaDescription = description
-    ? `${description.slice(0, 100)} | 칼로리 ${calory}kcal, 단백질 ${protein}g`
-    : `${name} 메뉴 정보와 주변 맛집을 확인하세요. 칼로리 ${calory}kcal`;
-
+  const title = `오메추 | 오늘의 메뉴는 [${name}]`;
+  const metaDescription =
+    "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?";
   const ogImage = image_link || "/og/og-image.png";
-
-  const keywords = [
-    name,
-    "메뉴추천",
-    "맛집",
-    "오늘뭐먹지",
-    ...(allergic || []),
-  ];
 
   return {
     title,
     description: metaDescription,
-    keywords,
+    keywords: [name, "메뉴추천", "맛집", "오늘뭐먹지"],
     openGraph: {
       title,
       description: metaDescription,
@@ -152,18 +140,19 @@ export function generateSummaryMetadata(
 }
 
 export function generateMinimalMetadata(
-  randomMenu: { name: string; image_link: string | null },
-  pageType: "랜덤 추천",
+  menuName: string,
+  imageLink: string | null,
   currentPath: string,
 ): Metadata {
-  const { name, image_link } = randomMenu;
-  const title = `${name} ${pageType}`;
-  const description = `${name} 메뉴를 추천받아보세요.`;
+  const title = `오메추 | 오늘의 메뉴는 [${menuName}]`;
+  const description =
+    "취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?";
+  const ogImage = imageLink || "/og/og-image.png";
 
   return {
     title,
     description,
-    keywords: [name, "메뉴추천", "맛집", "오늘뭐먹지"],
+    keywords: [menuName, "메뉴추천", "맛집", "오늘뭐먹지"],
     openGraph: {
       title,
       description,
@@ -173,10 +162,10 @@ export function generateMinimalMetadata(
       type: "website",
       images: [
         {
-          url: image_link || "/og/og-image.png",
+          url: ogImage,
           width: 800,
           height: 600,
-          alt: `${name} 이미지`,
+          alt: `${menuName} 이미지`,
         },
       ],
     },
@@ -184,7 +173,7 @@ export function generateMinimalMetadata(
       card: "summary_large_image",
       title,
       description,
-      images: [image_link || "/og/og-image.png"],
+      images: [ogImage],
     },
     robots: {
       index: true,

--- a/omechu-app/src/shared/lib/metadataFetchers.ts
+++ b/omechu-app/src/shared/lib/metadataFetchers.ts
@@ -1,4 +1,5 @@
 import type { RandomMenu, MenuListResponse } from "@/entities/menu";
+import type { BattleResponse } from "@/entities/menubattle";
 import { MenuDetail } from "@/shared/config/menu";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -60,6 +61,56 @@ export async function fetchRecommendMenuForMetadata(
     return data;
   } catch (error) {
     console.error("Failed to fetch recommend menu:", error);
+    return null;
+  }
+}
+
+export type BattleWinnerMenu = {
+  menuName: string;
+  imageLink: string | null;
+};
+
+export async function fetchBattleWinnerForMetadata(
+  battleId: string,
+): Promise<BattleWinnerMenu | null> {
+  try {
+    const response = await fetch(`${API_URL}/menu/battles/${battleId}`, {
+      next: { revalidate: 60 },
+    });
+
+    if (!response.ok) return null;
+
+    const raw: unknown = await response.json();
+    let battle: BattleResponse;
+
+    if (
+      typeof raw === "object" &&
+      raw !== null &&
+      "resultType" in raw &&
+      "success" in raw
+    ) {
+      battle = (raw as { success: BattleResponse }).success;
+    } else {
+      battle = raw as BattleResponse;
+    }
+
+    if (battle.status !== "finished" || battle.spinResults.length === 0) {
+      return null;
+    }
+
+    const winner = battle.spinResults.find((r) => r.rank === 1);
+    if (!winner) return null;
+
+    const winnerMenu = battle.menus.find(
+      (m) => m.menuName === winner.closestMenuName,
+    );
+
+    return {
+      menuName: winner.closestMenuName,
+      imageLink: winnerMenu?.imageLink ?? null,
+    };
+  } catch (error) {
+    console.error("Failed to fetch battle data:", error);
     return null;
   }
 }

--- a/omechu-app/src/shared/lib/metadataFetchers.ts
+++ b/omechu-app/src/shared/lib/metadataFetchers.ts
@@ -70,6 +70,18 @@ export type BattleWinnerMenu = {
   imageLink: string | null;
 };
 
+function isBattleResponse(data: unknown): data is BattleResponse {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "status" in data &&
+    "spinResults" in data &&
+    "menus" in data &&
+    Array.isArray((data as BattleResponse).spinResults) &&
+    Array.isArray((data as BattleResponse).menus)
+  );
+}
+
 export async function fetchBattleWinnerForMetadata(
   battleId: string,
 ): Promise<BattleWinnerMenu | null> {
@@ -81,7 +93,7 @@ export async function fetchBattleWinnerForMetadata(
     if (!response.ok) return null;
 
     const raw: unknown = await response.json();
-    let battle: BattleResponse;
+    let battle: BattleResponse | null = null;
 
     if (
       typeof raw === "object" &&
@@ -89,10 +101,15 @@ export async function fetchBattleWinnerForMetadata(
       "resultType" in raw &&
       "success" in raw
     ) {
-      battle = (raw as { success: BattleResponse }).success;
-    } else {
-      battle = raw as BattleResponse;
+      const wrapped = raw as { success: unknown };
+      if (isBattleResponse(wrapped.success)) {
+        battle = wrapped.success;
+      }
+    } else if (isBattleResponse(raw)) {
+      battle = raw;
     }
+
+    if (!battle) return null;
 
     if (battle.status !== "finished" || battle.spinResults.length === 0) {
       return null;


### PR DESCRIPTION
## 📌 PR 설명

결과 페이지 공유 시 실제 추천받은 메뉴와 다른 메뉴가 표시되던 문제를 수정하고, 타이틀/설명/이미지 형식을 QA 요구사항에 맞게 통일했습니다.

- [x] 공유 메타데이터 형식 통일 (타이틀: `오메추 | 오늘의 메뉴는 [메뉴명]`, 설명: `취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?`, 이미지: 메뉴 이미지)
- [x] `/mainpage/result/[menuId]` - 임베딩 API(fetchRecommendMenuForMetadata) 대신 메뉴 상세 API(fetchMenuDetailForMetadata)로 변경하여 실제 추천 메뉴 표시
- [x] `/random-recommend/[menuId]` - 랜덤 API 재호출(fetchRandomMenuForMetadata) 제거, URL의 메뉴명으로 직접 상세 조회
- [x] `/menu-battle/play/[id]` - layout.tsx 신규 생성, 배틀 종료 시 우승 메뉴로 메타데이터 생성

<br>

## 📷 스크린샷

**맞춤 추천 결과 (카이센동)**
```
og:title    → 오메추 | 오늘의 메뉴는 [카이센동]
og:desc     → 취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?
og:image    → https://omechu-service-s3-bucket.s3...카이센동.png
```

**랜덤 추천 결과 (짜장면)**
```
og:title    → 오메추 | 오늘의 메뉴는 [짜장면]
og:desc     → 취향에 딱 맞는 메뉴를 추천 받았어요! 오늘 식사는 이 메뉴로 정해볼까요?
og:image    → https://omechu-service-s3-bucket.s3...짜장면.png
```

<br>

## 🔍 추가 설명

### 원인 분석
- **맞춤 추천**: `fetchRecommendMenuForMetadata`가 임베딩 API를 호출하여 유사 메뉴 리스트를 반환하므로, 실제 추천 메뉴와 무관한 메뉴명이 메타데이터에 표시됨
- **랜덤 추천**: `fetchRandomMenuForMetadata`가 공유 시점에 새로운 랜덤 메뉴를 다시 요청하여, 원래 추천받은 메뉴와 불일치
- **메뉴 배틀**: 메타데이터 생성 로직(layout.tsx) 자체가 없었음

### 수정 방향
URL 파라미터의 메뉴명이 곧 실제 추천 메뉴이므로, `fetchMenuDetailForMetadata(decodedMenuId)`를 직접 호출하여 정확한 메뉴 정보(이름, 이미지)로 메타데이터를 생성하도록 변경

### 테스트 방법
dev 서버에서 curl로 OG 메타 태그 검증 완료:
```bash
curl -s http://localhost:3000/mainpage/result/{메뉴명} | grep 'og:'
curl -s http://localhost:3000/random-recommend/{메뉴명} | grep 'og:'
```