### PR TITLE
[FIX] Next/Image S3 호스트 허용 추가

### DIFF
--- a/omechu-app/next.config.ts
+++ b/omechu-app/next.config.ts
@@ -9,6 +9,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "omechu-s3-bucket.s3.ap-northeast-2.amazonaws.com",
       },
+      {
+        protocol: "https",
+        hostname: "omechu-service-s3-bucket.s3.ap-northeast-2.amazonaws.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
- Closes #323

---

## 📌 PR 설명

Next/Image 외부 이미지 허용 목록에 S3 호스트를 추가하여, 메뉴 이미지(S3 업로드)가 화면에서 차단되지 않도록 수정했습니다.

- [x] `omechu-service-s3-bucket.s3.ap-northeast-2.amazonaws.com` 허용 추가
- [x] 기존 `omechu-s3-bucket...` 허용은 유지

---

## 📷 스크린샷

UI 변경 없음 (이미지 로딩 설정만 변경)

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

- `/menu/allMenu/0` 응답의 `image_link`가 `omechu-service-s3-bucket...` 호스트로 내려오는 케이스를 확인했습니다.
- `next.config.ts`의 `images.remotePatterns`에서 미허용 호스트면 Next/Image가 이미지를 차단할 수 있어, 호스트를 추가했습니다.