### PR TITLE
[FIX] 메뉴 추천 결과 페이지 홈 버튼 모달 제거

### DIFF
--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import Image from "next/image";
 import {
@@ -19,10 +19,8 @@ import {
   useGetRestaurants,
 } from "@/entities/restaurant";
 import {
-  BaseModal,
   Header,
   IngredientCard,
-  ModalWrapper,
   RestaurantCard,
   SkeletonUIFoodBox,
   Toast,
@@ -41,9 +39,6 @@ export default function MenuDetailPage() {
   const detailMenu: MenuDetail | undefined = menuDetailData;
 
   const { mutate } = usePostMukburim();
-
-  // ✅ 홈 버튼 모달
-  const [showHomeModal, setShowHomeModal] = useState(false);
 
   // 토스트(공유/기록) 통합
   const [toastMessage, setToastMessage] = useState("");
@@ -208,7 +203,7 @@ export default function MenuDetailPage() {
         showHomeButton={true}
         showShareButton={true}
         onShareClick={handleShare}
-        onHomeClick={() => setShowHomeModal(true)}
+        onHomeClick={() => router.push("/mainpage")}
       />
 
       <div className="mt-4 flex-col items-center justify-center p-4">
@@ -307,22 +302,6 @@ export default function MenuDetailPage() {
           </>
         )}
       </div>
-
-      {showHomeModal && (
-        <ModalWrapper>
-          <BaseModal
-            title="메뉴추천을 중단하시겠어요?"
-            leftButtonText="그만하기"
-            rightButtonText="계속하기"
-            onCloseClick={() => setShowHomeModal(false)}
-            onLeftButtonClick={() => {
-              setShowHomeModal(false);
-              router.push("/mainpage");
-            }}
-            onRightButtonClick={() => setShowHomeModal(false)}
-          />
-        </ModalWrapper>
-      )}
 
       <Toast
         message={toastMessage}

--- a/omechu-app/src/entities/menubattle/ui/Winnercard.tsx
+++ b/omechu-app/src/entities/menubattle/ui/Winnercard.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import { useLocationAnswerStore } from "@/entities/location";
+import { handleLocation, useLocationAnswerStore } from "@/entities/location";
 import { fetchJSON } from "@/shared/api/fetchJSON";
 
 type WinnerCardProps = {
@@ -16,7 +16,8 @@ type WinnerCardProps = {
 
 export function WinnerCard({ winner }: WinnerCardProps) {
   const router = useRouter();
-  const { setKeyword } = useLocationAnswerStore();
+  const { setKeyword, setX, setY, setLocationDenied } =
+    useLocationAnswerStore();
   const [menuImage, setMenuImage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -34,6 +35,7 @@ export function WinnerCard({ winner }: WinnerCardProps) {
       type="button"
       onClick={() => {
         setKeyword(winner.closestMenuName);
+        handleLocation(setX, setY, setLocationDenied);
         router.push(
           `/mainpage/result/${encodeURIComponent(winner.closestMenuName)}`,
         );

--- a/omechu-app/src/entities/menubattle/ui/Winnercard.tsx
+++ b/omechu-app/src/entities/menubattle/ui/Winnercard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
+import { useLocationAnswerStore } from "@/entities/location";
 import { fetchJSON } from "@/shared/api/fetchJSON";
 
 type WinnerCardProps = {
@@ -15,6 +16,7 @@ type WinnerCardProps = {
 
 export function WinnerCard({ winner }: WinnerCardProps) {
   const router = useRouter();
+  const { setKeyword } = useLocationAnswerStore();
   const [menuImage, setMenuImage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -30,11 +32,12 @@ export function WinnerCard({ winner }: WinnerCardProps) {
   return (
     <button
       type="button"
-      onClick={() =>
+      onClick={() => {
+        setKeyword(winner.closestMenuName);
         router.push(
           `/mainpage/result/${encodeURIComponent(winner.closestMenuName)}`,
-        )
-      }
+        );
+      }}
       className="w-full rounded-2xl border-2 border-[#FF7A7A] bg-white px-4 py-3 text-left"
       aria-label={`${winner.closestMenuName} 메뉴 추천 결과 보기`}
     >


### PR DESCRIPTION
- Closes #343

---

## 📌 PR 설명

메뉴 추천 결과 페이지(`/random-recommend/[menuId]`)에서 헤더 홈 버튼 클릭 시 확인 모달을 제거하고 바로 `/mainpage`로 이동하도록 수정했습니다.

- [x] 홈 버튼 `onHomeClick`에서 모달 대신 `router.push("/mainpage")` 직접 호출
- [x] `showHomeModal` state 및 모달 JSX(`BaseModal`, `ModalWrapper`) 제거
- [x] 미사용 import 정리 (`BaseModal`, `ModalWrapper`, `useMemo`)

---

## 📷 스크린샷

| Before | After |
|--------|-------|
| 홈 버튼 → 모달("메뉴추천을 중단하시겠어요?") → 그만하기/계속하기 | 홈 버튼 → 바로 `/mainpage` 이동 |

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

QA 수정 중 첫 번째 항목입니다. 추가 QA 수정 작업이 남아있어 후속 PR이 이어질 예정입니다.