### PR TITLE
[FIX] 맞춤 추천 페이지네이션 버튼 데스크탑 위치 수정

### DIFF
--- a/omechu-app/src/app/(public)/mainpage/question-answer/[step]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/question-answer/[step]/page.tsx
@@ -126,7 +126,7 @@ export default function QuestionAnswerPage() {
       </main>
 
       {isQuestionStep && (
-        <nav className="pointer-events-none fixed inset-x-0 top-[55%] z-50 flex -translate-y-1/2 items-center justify-between px-4">
+        <nav className="pointer-events-none fixed top-[55%] left-1/2 z-50 flex w-full max-w-[480px] -translate-x-1/2 -translate-y-1/2 items-center justify-between px-4">
           {showPrev ? (
             <PaginationButton
               direction="left"


### PR DESCRIPTION
- Closes #345

---

## 📌 PR 설명

맞춤 추천 질문 페이지(`/mainpage/question-answer/[step]`)에서 좌우 페이지네이션 버튼이 데스크탑에서 화면 맨 끝에 위치하는 문제를 수정했습니다.

- [x] `fixed inset-x-0` → `fixed left-1/2 -translate-x-1/2 max-w-[480px]`
- [x] auth 페이지(BottomButton)와 동일한 중앙 정렬 패턴 적용

---

## 📷 스크린샷

| Before | After |
|--------|-------|
| 데스크탑에서 버튼이 화면 맨 끝에 위치 | 중앙 480px 영역 내에서 버튼 배치 |

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

auth signup 페이지의 `BottomButton className="mx-auto max-w-[480px]"` 패턴과 동일하게 적용하여 프로젝트 전체 UI 일관성을 유지합니다.