### PR TITLE
[FEAT] Header 홈 버튼 확인 모달 추가 및 페이지별 텍스트 커스텀

### DIFF
--- a/omechu-app/src/app/(public)/mainpage/question-answer/[step]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/question-answer/[step]/page.tsx
@@ -117,7 +117,13 @@ export default function QuestionAnswerPage() {
   return (
     <div className="relative flex h-screen w-auto flex-col">
       {/* header: 질문 스텝에서만 표시 */}
-      <Header title="맞춤 추천" showBackButton={false} />
+      <Header
+        title="맞춤 추천"
+        showBackButton={false}
+        homeModalTitle="메뉴 추천을 중단하시겠어요?"
+        homeModalLeftText="그만하기"
+        homeModalRightText="계속하기"
+      />
       <ProgressBar currentStep={currentStep} totalSteps={5} />
 
       <main className="flex min-h-[calc(100vh-9rem)] w-full flex-col items-center px-4 py-6">

--- a/omechu-app/src/app/(public)/menu-battle/page.tsx
+++ b/omechu-app/src/app/(public)/menu-battle/page.tsx
@@ -186,7 +186,13 @@ ${shareUrl}`;
 
   return (
     <main className="min-h-screen pb-32">
-      <Header title="메뉴 배틀" showProfileButton showHomeButton={false} />
+      <Header
+        title="오늘의 메뉴 배틀"
+        showBackButton={false}
+        homeModalTitle="메뉴 배틀을 중단하시겠어요?"
+        homeModalLeftText="그만하기"
+        homeModalRightText="계속하기"
+      />
 
       <section className="mt-2 px-4">
         <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">

--- a/omechu-app/src/app/(public)/menu-battle/play/[id]/page.tsx
+++ b/omechu-app/src/app/(public)/menu-battle/play/[id]/page.tsx
@@ -396,7 +396,13 @@ export default function PlayPage() {
 
   return (
     <main className="min-h-screen px-4 text-center">
-      <Header title={battleName} showProfileButton showHomeButton={false} />
+      <Header
+        title={battleName}
+        showBackButton={false}
+        homeModalTitle="메뉴 배틀을 중단하시겠어요?"
+        homeModalLeftText="그만하기"
+        homeModalRightText="계속하기"
+      />
 
       {ready && (
         <>

--- a/omechu-app/src/shared/ui/Header.tsx
+++ b/omechu-app/src/shared/ui/Header.tsx
@@ -1,5 +1,6 @@
-//! 26.01.17 리팩토링
 "use client";
+
+import { useState } from "react";
 
 import Image from "next/image";
 import Link from "next/link";
@@ -8,6 +9,8 @@ import { useRouter } from "next/navigation";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/shared/lib/cn.util";
+import { BaseModal } from "./modal/BaseModal";
+import { ModalWrapper } from "./modal/ModalWrapper";
 
 const headerStyles = cva(
   ["flex items-center justify-between", "w-full", "px-5 pt-5 pb-2.5"],
@@ -38,6 +41,10 @@ type HeaderProps = VariantProps<typeof headerStyles> & {
   onBackClick?: () => void;
   onHomeClick?: () => void;
 
+  homeModalTitle?: string;
+  homeModalLeftText?: string;
+  homeModalRightText?: string;
+
   className?: string;
 };
 
@@ -53,13 +60,22 @@ export const Header = ({
 
   onBackClick,
   onHomeClick,
+  homeModalTitle = "홈으로 돌아가시겠어요?",
+  homeModalLeftText = "네",
+  homeModalRightText = "아니요",
   className,
 }: HeaderProps) => {
   const router = useRouter();
+  const [showHomeModal, setShowHomeModal] = useState(false);
 
   const handleBack = () => {
     if (onBackClick) onBackClick();
     else router.back();
+  };
+
+  const handleHomeConfirm = () => {
+    setShowHomeModal(false);
+    router.push("/mainpage");
   };
 
   // mypage variant: 프로필 아이콘만 표시
@@ -74,6 +90,7 @@ export const Header = ({
   }
 
   return (
+    <>
     <header className={cn(headerStyles({ variant }), className)}>
       {/* 왼쪽: 뒤로가기 버튼 */}
       {showBackButton ? (
@@ -112,20 +129,14 @@ export const Header = ({
         )}
 
         {showHomeButton ? (
-          onHomeClick ? (
-            <button
-              type="button"
-              onClick={onHomeClick}
-              aria-label="홈으로"
-              className="shrink-0"
-            >
-              <Image src="/header/home.svg" alt="" width={24} height={24} />
-            </button>
-          ) : (
-            <Link href="/mainpage" aria-label="홈으로" className="shrink-0">
-              <Image src="/header/home.svg" alt="" width={24} height={24} />
-            </Link>
-          )
+          <button
+            type="button"
+            onClick={onHomeClick ?? (() => setShowHomeModal(true))}
+            aria-label="홈으로"
+            className="shrink-0"
+          >
+            <Image src="/header/home.svg" alt="" width={24} height={24} />
+          </button>
         ) : showProfileButton ? (
           <Link href="/mypage" aria-label="마이페이지" className="shrink-0">
             <Image src="/header/person.svg" alt="" width={24} height={24} />
@@ -135,5 +146,19 @@ export const Header = ({
         )}
       </div>
     </header>
+
+    {showHomeModal && (
+      <ModalWrapper>
+        <BaseModal
+          title={homeModalTitle}
+          leftButtonText={homeModalLeftText}
+          rightButtonText={homeModalRightText}
+          onCloseClick={() => setShowHomeModal(false)}
+          onLeftButtonClick={handleHomeConfirm}
+          onRightButtonClick={() => setShowHomeModal(false)}
+        />
+      </ModalWrapper>
+    )}
+    </>
   );
 };

--- a/omechu-app/src/shared/ui/Header.tsx
+++ b/omechu-app/src/shared/ui/Header.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/shared/lib/cn.util";
+
 import { BaseModal } from "./modal/BaseModal";
 import { ModalWrapper } from "./modal/ModalWrapper";
 
@@ -91,74 +92,79 @@ export const Header = ({
 
   return (
     <>
-    <header className={cn(headerStyles({ variant }), className)}>
-      {/* 왼쪽: 뒤로가기 버튼 */}
-      {showBackButton ? (
-        <button
-          type="button"
-          onClick={handleBack}
-          className="shrink-0"
-          aria-label="뒤로가기"
-        >
-          <Image src="/header/chevron-left.svg" alt="" width={24} height={24} />
-        </button>
-      ) : (
-        <div className="w-6 shrink-0" />
-      )}
-
-      {/* 중앙: 타이틀 */}
-      <div className="mx-2 flex-1">
-        {title && (
-          <p className="text-body-3-medium text-font-high text-center">
-            {title}
-          </p>
-        )}
-      </div>
-
-      {/* 오른쪽: 공유 + 홈/프로필 */}
-      <div className="flex shrink-0 items-center gap-3">
-        {showShareButton && (
+      <header className={cn(headerStyles({ variant }), className)}>
+        {/* 왼쪽: 뒤로가기 버튼 */}
+        {showBackButton ? (
           <button
             type="button"
-            onClick={onShareClick}
-            aria-label="공유하기"
+            onClick={handleBack}
             className="shrink-0"
+            aria-label="뒤로가기"
           >
-            <Image src="/share/share.svg" alt="" width={24} height={24} />
+            <Image
+              src="/header/chevron-left.svg"
+              alt=""
+              width={24}
+              height={24}
+            />
           </button>
-        )}
-
-        {showHomeButton ? (
-          <button
-            type="button"
-            onClick={onHomeClick ?? (() => setShowHomeModal(true))}
-            aria-label="홈으로"
-            className="shrink-0"
-          >
-            <Image src="/header/home.svg" alt="" width={24} height={24} />
-          </button>
-        ) : showProfileButton ? (
-          <Link href="/mypage" aria-label="마이페이지" className="shrink-0">
-            <Image src="/header/person.svg" alt="" width={24} height={24} />
-          </Link>
         ) : (
           <div className="w-6 shrink-0" />
         )}
-      </div>
-    </header>
 
-    {showHomeModal && (
-      <ModalWrapper>
-        <BaseModal
-          title={homeModalTitle}
-          leftButtonText={homeModalLeftText}
-          rightButtonText={homeModalRightText}
-          onCloseClick={() => setShowHomeModal(false)}
-          onLeftButtonClick={handleHomeConfirm}
-          onRightButtonClick={() => setShowHomeModal(false)}
-        />
-      </ModalWrapper>
-    )}
+        {/* 중앙: 타이틀 */}
+        <div className="mx-2 flex-1">
+          {title && (
+            <p className="text-body-3-medium text-font-high text-center">
+              {title}
+            </p>
+          )}
+        </div>
+
+        {/* 오른쪽: 공유 + 홈/프로필 */}
+        <div className="flex shrink-0 items-center gap-3">
+          {showShareButton && (
+            <button
+              type="button"
+              onClick={onShareClick}
+              aria-label="공유하기"
+              className="shrink-0"
+            >
+              <Image src="/share/share.svg" alt="" width={24} height={24} />
+            </button>
+          )}
+
+          {showHomeButton ? (
+            <button
+              type="button"
+              onClick={onHomeClick ?? (() => setShowHomeModal(true))}
+              aria-label="홈으로"
+              className="shrink-0"
+            >
+              <Image src="/header/home.svg" alt="" width={24} height={24} />
+            </button>
+          ) : showProfileButton ? (
+            <Link href="/mypage" aria-label="마이페이지" className="shrink-0">
+              <Image src="/header/person.svg" alt="" width={24} height={24} />
+            </Link>
+          ) : (
+            <div className="w-6 shrink-0" />
+          )}
+        </div>
+      </header>
+
+      {showHomeModal && (
+        <ModalWrapper>
+          <BaseModal
+            title={homeModalTitle}
+            leftButtonText={homeModalLeftText}
+            rightButtonText={homeModalRightText}
+            onCloseClick={() => setShowHomeModal(false)}
+            onLeftButtonClick={handleHomeConfirm}
+            onRightButtonClick={() => setShowHomeModal(false)}
+          />
+        </ModalWrapper>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 🔀 Pull Request Title

FEAT: Header 홈 버튼 확인 모달 추가 및 페이지별 텍스트 커스텀

- Closes #3

<br>

## 📌 PR 설명

Header 컴포넌트에 홈 버튼 클릭 시 확인 모달을 내장하고, 페이지별로 모달 텍스트를 커스텀할 수 있도록 수정했습니다.

- [x] Header에 홈 모달 기능 내장 (`homeModalTitle`, `homeModalLeftText`, `homeModalRightText` props 추가)
- [x] question-answer 페이지: "메뉴 추천을 중단하시겠어요?" / "그만하기" / "계속하기"
- [x] menu-battle, menu-battle/play 페이지: "메뉴 배틀을 중단하시겠어요?" / "그만하기" / "계속하기"

<br>

## 📷 스크린샷

https://github.com/user-attachments/assets/12b007bb-0c9a-433a-993d-2406a357f85e


<br>

## 🔍 추가 설명

- 기존 홈 버튼은 Link 또는 커스텀 핸들러로 분기되어 있었으나, 모달 확인 후 이동하는 방식으로 통일
- 기본 모달 텍스트: "홈으로 돌아가시겠어요?" / "네" / "아니요"
- `onHomeClick` prop이 전달되면 모달 대신 해당 핸들러가 실행됨
- `pnpm build` 정상 통과 확인 완료