### PR TITLE
[CHORE] robots.txt에 Yeti(네이버봇) 및 Googlebot 명시적 추가

### DIFF
--- a/omechu-app/src/app/robots.ts
+++ b/omechu-app/src/app/robots.ts
@@ -10,6 +10,14 @@ export default function robots(): MetadataRoute.Robots {
         allow: "/",
       },
       {
+        userAgent: "Yeti",
+        allow: "/",
+      },
+      {
+        userAgent: "Googlebot",
+        allow: "/",
+      },
+      {
         userAgent: "GPTBot",
         allow: "/",
       },


### PR DESCRIPTION
- Closes #356

---

## 📌 PR 설명

네이버 서치어드바이저 robots.txt 검증 도구에서 Yeti 규칙이 명시적으로 표시되지 않는 문제를 해결합니다. 실무 표준에 따라 주요 검색봇을 명시적으로 선언합니다.

- [x] `Yeti` (네이버 검색봇) 명시적 추가
- [x] `Googlebot` 명시적 추가

---

## 🏷 변경 유형

- [ ] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/디자인 변경 (style/design)
- [ ] 문서 수정 (docs)
- [ ] 빌드/CI 설정 (build/ci)
- [x] 기타 (chore)

---

## 📷 스크린샷

해당 없음

---

## ✅ FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

**변경 전**
```
User-Agent: *
Allow: /
User-Agent: GPTBot / Google-Extended / ClaudeBot
Allow: /
```

**변경 후**
```
User-Agent: *
Allow: /
User-Agent: Yeti     ← 네이버봇 명시적 추가
Allow: /
User-Agent: Googlebot ← 구글봇 명시적 추가
Allow: /
User-Agent: GPTBot / Google-Extended / ClaudeBot
Allow: /
```

배포 후 네이버 서치어드바이저 → 도구 설정 → robots.txt 검증에서 `https://omechu.log8.kr` 입력 시 Yeti 규칙이 명시적으로 확인됩니다.