### PR TITLE
[FIX] 먹부림 기록 이미지 및 result 페이지 UI 개선

### DIFF
--- a/omechu-app/.gitignore
+++ b/omechu-app/.gitignore
@@ -7,7 +7,7 @@ out/
 build/
 
 # env files
-.env
+.env.*
 .env.local
 .env.production
 .env.development

--- a/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
@@ -179,7 +179,7 @@ export default function MukburimLogPage() {
                 <MukburimFoodBox
                   key={item.menu_name}
                   frequency={String(item.count)}
-                  src="/image/image_empty.svg"
+                  src={item.image_link}
                   title={item.menu_name}
                 />
               ))}

--- a/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/mukburim-log/page.tsx
@@ -90,7 +90,7 @@ export default function MukburimLogPage() {
         throw error;
       }
     },
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
   });
 
   const menuStatistics = data?.success?.menuStatistics ?? [];

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
@@ -206,7 +206,7 @@ export default function MenuDetailPage() {
   };
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex w-full flex-col items-center">
       <Header
         title="오늘의 메뉴"
         showBackButton={false}
@@ -229,7 +229,7 @@ export default function MenuDetailPage() {
         />
       </div>
 
-      <div className="mt-10 ml-4 w-full p-4">
+      <div className="mt-10 ml-4 w-fit p-4">
         <IngredientCard
           kcal={detailMenu?.calory}
           carbohydrate={detailMenu?.carbo}
@@ -240,7 +240,7 @@ export default function MenuDetailPage() {
         />
       </div>
 
-      <div className="mt-3 ml-4 items-center justify-center space-y-3.5 px-4 pb-6">
+      <div className="mt-3 ml-4 w-fit items-center justify-center space-y-3.5 px-4 pb-6">
         <h3 className="text-font-high text-body-3-medium text-[1.125rem] whitespace-nowrap">
           취향 저격! 추천 메뉴 있는 맛집
         </h3>

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
@@ -24,7 +24,7 @@ import {
   IngredientCard,
   ModalWrapper,
   RestaurantCard,
-  SkeletonUIFoodBox,
+  SkeletonRecommendedFoodCard,
   Toast,
   type MenuDetail,
 } from "@/shared";
@@ -266,7 +266,7 @@ export default function MenuDetailPage() {
             {(isLoading || (isFetching && restaurants.length === 0)) && (
               <div className="flex flex-col gap-4">
                 {Array.from({ length: 3 }).map((_, i) => (
-                  <SkeletonUIFoodBox key={i} />
+                  <SkeletonRecommendedFoodCard key={i} />
                 ))}
               </div>
             )}

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
@@ -229,7 +229,7 @@ export default function MenuDetailPage() {
         />
       </div>
 
-      <div className="mt-10 ml-4 w-fit p-4">
+      <div className="ml-4 w-fit p-4">
         <IngredientCard
           kcal={detailMenu?.calory}
           carbohydrate={detailMenu?.carbo}

--- a/omechu-app/src/app/(public)/mainpage/result/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/page.tsx
@@ -170,7 +170,7 @@ export default function ResultPage() {
   // if (error) ...
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-screen flex-col items-center">
       <Header
         title="맞춤 추천"
         onBackClick={() => router.back()}
@@ -193,16 +193,16 @@ export default function ResultPage() {
         ))}
       </div>
 
-      <div className="mt-2 flex gap-2 px-4 py-2">
+      <div className="mt-2 flex w-[330px] gap-2 py-2">
         <Button
-          className="hover:bg-grey-normal flex-1 rounded-md border border-[#2424243d] bg-[#EEE] px-4 py-2 text-[#393939]"
+          className="hover:bg-grey-normal text-foundation-grey-darker border-font-disabled rounded-md border bg-[#EEE] px-4 py-2"
           onClick={handleReshuffle}
         >
           다시 추천
         </Button>
 
         <Button
-          className="bg-primary-normal hover:bg-primary-normal-hover flex-1 rounded-md px-4 py-2 text-[#FFF]"
+          className="bg-primary-normal hover:bg-primary-normal-hover rounded-md px-4 py-2 text-[#FFF]"
           onClick={handleNext}
         >
           선택하기

--- a/omechu-app/src/app/(public)/mainpage/result/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/page.tsx
@@ -193,16 +193,16 @@ export default function ResultPage() {
         ))}
       </div>
 
-      <div className="mt-2 flex w-[330px] gap-2 py-2">
+      <div className="mt-2 flex w-82.5 gap-2 py-2">
         <Button
-          className="hover:bg-grey-normal text-foundation-grey-darker border-font-disabled rounded-md border bg-[#EEE] px-4 py-2"
+          className="hover:bg-grey-normal text-foundation-grey-darker border-font-disabled flex-1 rounded-md border bg-[#EEE] px-4 py-2"
           onClick={handleReshuffle}
         >
           다시 추천
         </Button>
 
         <Button
-          className="bg-primary-normal hover:bg-primary-normal-hover rounded-md px-4 py-2 text-[#FFF]"
+          className="bg-primary-normal hover:bg-primary-normal-hover flex-1 rounded-md px-4 py-2 text-[#FFF]"
           onClick={handleNext}
         >
           선택하기

--- a/omechu-app/src/entities/mukburim/model/mukburim.types.ts
+++ b/omechu-app/src/entities/mukburim/model/mukburim.types.ts
@@ -29,6 +29,7 @@ export interface GetMukburimStatisticsParams {
 /** 메뉴별 통계 아이템 */
 export interface MukburimMenuStatistic {
   menu_name: string;
+  image_link: string;
   count: number;
   last_eaten_at: string;
   last_eaten_date: string;

--- a/omechu-app/src/shared/index.ts
+++ b/omechu-app/src/shared/index.ts
@@ -64,6 +64,7 @@ export { ListButton } from "./ui/button/ListButton";
 // FoodCard는 widgets/card로 이동 (FSD: entities 의존)
 export { IngredientCard } from "./ui/card/IngredientCard";
 export { RecommendedFoodCard } from "./ui/card/RecommendedFoodCard";
+export { SkeletonRecommendedFoodCard } from "./ui/card/SkeletonRecommendedFoodCard";
 export { RestaurantCard } from "./ui/card/RestaurantCard";
 
 // UI - Modal

--- a/omechu-app/src/shared/ui/card/SkeletonRecommendedFoodCard.tsx
+++ b/omechu-app/src/shared/ui/card/SkeletonRecommendedFoodCard.tsx
@@ -1,0 +1,14 @@
+export function SkeletonRecommendedFoodCard() {
+  return (
+    <div className="relative">
+      <div className="bg-brand-secondary flex h-28 w-84 animate-pulse gap-5 rounded-2xl border-[1.5px] border-gray-200 p-3">
+        <div className="h-22 w-22 rounded-2xl bg-gray-200" />
+        <div className="flex w-48 flex-col gap-2 pt-1">
+          <div className="h-4 w-24 rounded bg-gray-200" />
+          <div className="h-3 w-full rounded bg-gray-200" />
+          <div className="h-3 w-3/4 rounded bg-gray-200" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/omechu-app/src/widgets/mypage/ui/MukburimFoodBox.tsx
+++ b/omechu-app/src/widgets/mypage/ui/MukburimFoodBox.tsx
@@ -2,7 +2,11 @@
 
 "use client";
 
+import { useState } from "react";
+
 import Image from "next/image";
+
+const FALLBACK_IMAGE = "/image/image_empty.svg";
 
 interface MukburimFoodBoxProps {
   src: string;
@@ -15,13 +19,15 @@ export const MukburimFoodBox = ({
   frequency = "0",
   title,
 }: MukburimFoodBoxProps) => {
+  const [imgSrc, setImgSrc] = useState(src || FALLBACK_IMAGE);
+
   return (
     <div className="relatvie bg-brand-secondary relative h-25 w-25 rounded-xl transition-all">
       <span className="text-body-4-medium text-font-high absolute top-1 left-1/2 -translate-x-1/2">
         {frequency} 회
       </span>
       <Image
-        src={src || "/image/image_empty.svg"}
+        src={imgSrc}
         alt={`${title} 메뉴 이미지`}
         width={100}
         height={100}
@@ -29,6 +35,7 @@ export const MukburimFoodBox = ({
         loading="lazy"
         unoptimized={false}
         className="rounded-xl object-fill"
+        onError={() => setImgSrc(FALLBACK_IMAGE)}
       />
       <span className="text-body-4-medium text-font-high absolute bottom-1 left-1/2 w-full -translate-x-1/2 text-center">
         {title}

--- a/omechu-app/src/widgets/mypage/ui/PeriodTap.tsx
+++ b/omechu-app/src/widgets/mypage/ui/PeriodTap.tsx
@@ -21,7 +21,7 @@ type Period = (typeof PERIOD_OPTIONS)[number];
 
 export function PeriodTap({ value, onChange }: PeriodTapProps) {
   return (
-    <section className="h-12 overflow-x-auto px-5 pb-2.5">
+    <section className="h-fit overflow-x-auto px-5 pb-2.5">
       <div className="border-font-extra-low relative flex h-full w-max flex-nowrap items-end gap-4 border-b">
         {PERIOD_OPTIONS.map((item) => (
           <button


### PR DESCRIPTION
## PR 설명

- [x] MukburimFoodBox 이미지 로드 실패 시 폴백 이미지 처리 추가
- [x] 먹부림 기록에 실제 메뉴 이미지(image_link) 연결
- [x] result / menuDetail 페이지 레이아웃 정렬 및 버튼 스타일 개선
- [x] PeriodTap 높이를 콘텐츠 기반(h-fit)으로 변경
- [x] MenuDetailPage IngredientCard 상단 여백 제거
- [x] .gitignore env 패턴 통합
- [x] RecommendedFoodCard 스켈레톤 UI 컴포넌트 추가
- [x] MenuDetailPage 스켈레톤을 SkeletonRecommendedFoodCard로 교체

<br>

## 스크린샷
<img width="470" height="1281" alt="스크린샷 2026-02-24 오후 4 33 49" src="https://github.com/user-attachments/assets/67d3caf6-7f31-469c-ad44-151640ff5ee9" />

<img width="563" height="773" alt="스크린샷 2026-02-24 오후 4 41 12" src="https://github.com/user-attachments/assets/5af3c29b-7f95-4237-8fdc-4ed1ab33ad3b" />

<img width="475" height="769" alt="스크린샷 2026-02-24 오후 4 59 07" src="https://github.com/user-attachments/assets/c6d1ac67-2f47-4e86-aeeb-c143aa4b5865" />

https://github.com/user-attachments/assets/0e7d2e5d-b0bc-4714-b1b8-8864d574c49d

<br>

## 추가 설명

- 먹부림 에러 처리(MK001 HTTP 상태코드 의존 제거)는 별도 브랜치(`fix/mukburim-log-error-handling`)에서 관리합니다.
- 백엔드에서 MK001(기록 없음) 에러를 500으로 반환하는 부분은 추후 200 또는 404로 수정 요청 필요합니다.

## 관련 QA
- [날짜 조회 탭 가려짐](https://www.notion.so/310bdaed2ef580f3aebddfa2e85f47a0?source=copy_link)
- [메뉴 추천 결과 가운데 맞춤](https://www.notion.so/311bdaed2ef580a2aa73d7c7f88de9c7?source=copy_link)
- [먹부림 기록 조회 안됨](https://www.notion.so/30cbdaed2ef580c8b40be36e4771007c?v=26fbdaed2ef58044a9dd000cfe81ad57&source=copy_link)