### PR TITLE
[STYLE] 메뉴 상세 및 랜덤 추천 페이지 UI 개선

### DIFF
--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
@@ -29,8 +29,6 @@ import {
   type MenuDetail,
 } from "@/shared";
 
-const PAGE_SIZE = 3;
-
 export default function MenuDetailPage() {
   const router = useRouter();
   const pathname = usePathname();
@@ -223,7 +221,7 @@ export default function MenuDetailPage() {
         <Image
           src={detailMenu?.image_link || "/image/image_empty.svg"}
           alt={detailMenu?.name || "메뉴 이미지"}
-          className="mx-auto h-24 w-24 rounded-md"
+          className="mx-auto h-28 w-28 rounded-md"
           width={96}
           height={96}
         />

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
@@ -215,13 +215,13 @@ export default function MenuDetailPage() {
       />
 
       <div className="mt-4 ml-4 flex-col items-center justify-center p-4">
-        <p className="text-brand-primary mb-3 text-center text-[1.5rem] font-semibold">
+        <p className="text-brand-primary text-body-1 mb-3 text-center font-semibold">
           {detailMenu?.name}
         </p>
         <Image
           src={detailMenu?.image_link || "/image/image_empty.svg"}
           alt={detailMenu?.name || "메뉴 이미지"}
-          className="mx-auto h-28 w-28 rounded-md"
+          className="mx-auto h-32 w-32 rounded-md"
           width={96}
           height={96}
         />
@@ -239,7 +239,7 @@ export default function MenuDetailPage() {
       </div>
 
       <div className="mt-3 ml-4 w-fit items-center justify-center space-y-3.5 px-4 pb-6">
-        <h3 className="text-font-high text-body-3-medium text-[1.125rem] whitespace-nowrap">
+        <h3 className="text-font-high text-body-3-medium text-body-3 whitespace-nowrap">
           취향 저격! 추천 메뉴 있는 맛집
         </h3>
         {/* 404 or 위치 차단 */}
@@ -249,12 +249,12 @@ export default function MenuDetailPage() {
               맛집 정보를 불러올 수 없습니다.
             </p>
             {locationDenied ? (
-              <p className="mt-2 text-center text-[0.875rem] text-neutral-600">
+              <p className="text-caption-1 mt-2 text-center text-neutral-600">
                 위치 권한이 꺼져 있어요. 브라우저/기기 설정에서 위치 권한을
                 허용해 주세요.
               </p>
             ) : (
-              <p className="mt-2 text-center text-[0.875rem] text-neutral-600">
+              <p className="text-caption-1 mt-2 text-center text-neutral-600">
                 해당 위치 또는 키워드 조건에 맞는 맛집이 없어요.
               </p>
             )}

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
@@ -22,7 +22,7 @@ import {
   Header,
   IngredientCard,
   RestaurantCard,
-  SkeletonUIFoodBox,
+  SkeletonRecommendedFoodCard,
   Toast,
   type MenuDetail,
 } from "@/shared";
@@ -197,7 +197,7 @@ export default function MenuDetailPage() {
   };
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex flex-col items-center">
       <Header
         title="오늘의 메뉴"
         showHomeButton={true}
@@ -207,19 +207,19 @@ export default function MenuDetailPage() {
       />
 
       <div className="mt-4 flex-col items-center justify-center p-4">
-        <p className="text-brand-primary mb-3 text-center text-[1.5rem] font-semibold">
+        <p className="text-brand-primary text-body-1 mb-3 text-center font-semibold">
           {detailMenu?.name}
         </p>
         <Image
           src={detailMenu?.image_link || "/image/image_empty.svg"}
           alt={detailMenu?.name || "메뉴 이미지"}
-          className="mx-auto h-24 w-24 rounded-md"
+          className="mx-auto h-32 w-32 rounded-md"
           width={96}
           height={96}
         />
       </div>
 
-      <div className="mt-10 ml-4 w-full p-4">
+      <div className="ml-4 w-fit p-4">
         <IngredientCard
           kcal={detailMenu?.calory}
           carbohydrate={detailMenu?.carbo}
@@ -231,7 +231,7 @@ export default function MenuDetailPage() {
       </div>
 
       <div className="mt-3 ml-4 items-center justify-center space-y-3.5 px-4">
-        <h3 className="text-font-high text-body-3-medium text-[1.125rem] font-semibold whitespace-nowrap">
+        <h3 className="text-font-high text-body-3-medium text-body-3 font-semibold whitespace-nowrap">
           취향 저격! 추천 메뉴 있는 맛집
         </h3>
         {/* 404 or 위치 차단 */}
@@ -241,12 +241,12 @@ export default function MenuDetailPage() {
               맛집 정보를 불러올 수 없습니다.
             </p>
             {locationDenied ? (
-              <p className="mt-2 text-center text-[0.875rem] text-neutral-600">
+              <p className="text-caption-1 mt-2 text-center text-neutral-600">
                 위치 권한이 꺼져 있어요. 브라우저/기기 설정에서 위치 권한을
                 허용해 주세요.
               </p>
             ) : (
-              <p className="mt-2 text-center text-[0.875rem] text-neutral-600">
+              <p className="text-caption-1 mt-2 text-center text-neutral-600">
                 해당 위치 또는 키워드 조건에 맞는 맛집이 없어요.
               </p>
             )}
@@ -256,7 +256,7 @@ export default function MenuDetailPage() {
             {(isLoading || (isFetching && restaurants.length === 0)) && (
               <div className="flex flex-col gap-4">
                 {Array.from({ length: 3 }).map((_, i) => (
-                  <SkeletonUIFoodBox key={i} />
+                  <SkeletonRecommendedFoodCard key={i} />
                 ))}
               </div>
             )}

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
@@ -200,6 +200,7 @@ export default function MenuDetailPage() {
     <div className="flex flex-col items-center">
       <Header
         title="오늘의 메뉴"
+        showBackButton={false}
         showHomeButton={true}
         showShareButton={true}
         onShareClick={handleShare}

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
@@ -21,6 +21,8 @@ import {
 import {
   Header,
   IngredientCard,
+  ModalWrapper,
+  BaseModal,
   RestaurantCard,
   SkeletonRecommendedFoodCard,
   Toast,
@@ -41,6 +43,7 @@ export default function MenuDetailPage() {
   const { mutate } = usePostMukburim();
 
   // 토스트(공유/기록) 통합
+  const [showHomeModal, setShowHomeModal] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
   const [showToast, setShowToast] = useState(false);
   const toastTimerRef = useRef<number | null>(null);
@@ -204,7 +207,7 @@ export default function MenuDetailPage() {
         showHomeButton={true}
         showShareButton={true}
         onShareClick={handleShare}
-        onHomeClick={() => router.push("/mainpage")}
+        onHomeClick={() => setShowHomeModal(true)}
       />
 
       <div className="mt-4 flex-col items-center justify-center p-4">
@@ -303,6 +306,22 @@ export default function MenuDetailPage() {
           </>
         )}
       </div>
+
+      {showHomeModal && (
+        <ModalWrapper>
+          <BaseModal
+            title="메뉴추천을 중단하시겠어요?"
+            leftButtonText="그만하기"
+            rightButtonText="계속하기"
+            onCloseClick={() => setShowHomeModal(false)}
+            onLeftButtonClick={() => {
+              setShowHomeModal(false);
+              router.push("/mainpage");
+            }}
+            onRightButtonClick={() => setShowHomeModal(false)}
+          />
+        </ModalWrapper>
+      )}
 
       <Toast
         message={toastMessage}

--- a/omechu-app/src/widgets/RandomDraw/ui/RandomDrawSelector.tsx
+++ b/omechu-app/src/widgets/RandomDraw/ui/RandomDrawSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
+
 import clsx from "clsx";
 
 import {
@@ -59,7 +60,7 @@ export function RandomDrawSelector({
   const rows = useMemo(() => RANDOM_DRAW_GROUPS, []);
 
   return (
-    <div className={clsx("w-full max-w-[360px] p-2", className)}>
+    <div className={clsx("w-full max-w-90 p-2", className)}>
       {rows.map((group, idx) => {
         const isFirst = idx === 0;
 
@@ -72,7 +73,7 @@ export function RandomDrawSelector({
                 "border-font-placeholder/80 mt-4 border-t pt-4",
             )}
           >
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap justify-center gap-3">
               {group.options.map((opt) => {
                 const selected = selection[group.key].includes(opt.value);
 


### PR DESCRIPTION
## PR 설명

- [x] MenuDetailPage / RandomRecommendPage 메뉴 이미지 크기 확대 (h-24 -> h-28, h-32)
- [x] MenuDetailPage 하드코딩 폰트 크기를 디자인 시스템 토큰으로 교체
- [x] RandomDrawSelector 최대 너비 통일 및 옵션 중앙 정렬
- [x] RandomRecommendPage Header 뒤로가기 버튼 숨김 처리
- [x] RandomRecommendPage 홈 버튼에 추천 중단 확인 모달 연결

<br>

## 스크린샷

UI 변경이 있을 경우 스크린샷을 첨부해주세요.

<br>

## 추가 설명

- 하드코딩 색상/폰트 값을 디자인 시스템 토큰(`text-body-1`, `text-body-3`, `text-caption-1`)으로 교체하여 일관성 확보
- RandomRecommendPage는 랜덤 추천 결과 페이지로 뒤로가기보다 홈 이동이 적절하여 뒤로가기 버튼 숨김 + 홈 버튼 모달 추가