### PR TITLE
[FEAT] 먹부림 기록 개선 - 중복 방지 제거 및 FAB 스크롤 표시/숨김

### DIFF
--- a/omechu-app/src/app/(private)/mypage/recommended-list/page.tsx
+++ b/omechu-app/src/app/(private)/mypage/recommended-list/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -11,6 +11,8 @@ import {
 } from "@/entities/user";
 import { MENU_SUGGESTIONS } from "@/shared/constants/mypage";
 import { Header, SearchBar } from "@/shared/index";
+import { useToast } from "@/shared/lib/useToast";
+import { Toast } from "@/shared/ui/toast/Toast";
 import {
   FloatingActionButton,
   RecommendedFoodBox,
@@ -28,6 +30,21 @@ export default function RecommendedListPage() {
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
+  const [showFAB, setShowFAB] = useState(false);
+  const [toastState, setToastState] = useState<"success" | "error">("success");
+  const { show, message, triggerToast } = useToast();
+
+  useEffect(() => {
+    const el = mainRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      setShowFAB(el.scrollTop > 200);
+    };
+
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const { data, isLoading } = useRecommendManagement();
   const exceptMutation = useExceptMenuMutation();
@@ -46,10 +63,25 @@ export default function RecommendedListPage() {
   }, [data, selectedIndex, searchTerm]);
 
   const handleToggle = (menuId: string) => {
+    const callbacks = {
+      onSuccess: () => {
+        setToastState("success");
+        triggerToast(
+          selectedIndex === TAB.RECOMMEND
+            ? "제외 목록에 추가되었습니다."
+            : "추천 목록으로 복원되었습니다.",
+        );
+      },
+      onError: () => {
+        setToastState("error");
+        triggerToast("처리 중 오류가 발생했습니다.");
+      },
+    };
+
     if (selectedIndex === TAB.RECOMMEND) {
-      exceptMutation.mutate({ menuId });
+      exceptMutation.mutate({ menuId }, callbacks);
     } else {
-      removeExceptMutation.mutate({ menuId });
+      removeExceptMutation.mutate({ menuId }, callbacks);
     }
   };
 
@@ -114,8 +146,21 @@ export default function RecommendedListPage() {
           </section>
         )}
 
-        <FloatingActionButton onClick={scrollToTop} />
+        <FloatingActionButton
+          onClick={scrollToTop}
+          className={
+            showFAB
+              ? "opacity-100 transition-opacity duration-300"
+              : "pointer-events-none opacity-0 transition-opacity duration-300"
+          }
+        />
       </main>
+      <Toast
+        message={message}
+        show={show}
+        state={toastState}
+        className="bottom-20"
+      />
     </>
   );
 }

--- a/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/mainpage/result/[menuId]/page.tsx
@@ -96,22 +96,14 @@ export default function MenuDetailPage() {
   useEffect(() => {
     if (!decodeMenuId || !shouldRecord) return;
 
-    const key = `mukburim-recorded:${decodeMenuId}`;
-    const already = sessionStorage.getItem(key);
-
-    if (already) {
-      cleanQuery();
-      return;
-    }
-
-    cleanQuery();
-
     mutate(decodeMenuId, {
       onSuccess: () => {
         openToast("먹부림 기록에 등록되었습니다.", 2000);
-        sessionStorage.setItem(key, "done");
       },
       onError: () => {},
+      onSettled: () => {
+        cleanQuery();
+      },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decodeMenuId, shouldRecord]);

--- a/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
+++ b/omechu-app/src/app/(public)/random-recommend/[menuId]/page.tsx
@@ -95,22 +95,14 @@ export default function MenuDetailPage() {
   useEffect(() => {
     if (!decodeMenuId || !shouldRecord) return;
 
-    const key = `mukburim-recorded:${decodeMenuId}`;
-    const already = sessionStorage.getItem(key);
-
-    if (already) {
-      cleanQuery();
-      return;
-    }
-
-    cleanQuery();
-
     mutate(decodeMenuId, {
       onSuccess: () => {
         openToast("먹부림 기록에 등록되었습니다.", 2000);
-        sessionStorage.setItem(key, "done");
       },
       onError: () => {},
+      onSettled: () => {
+        cleanQuery();
+      },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decodeMenuId, shouldRecord]);

--- a/omechu-app/src/entities/mukburim/model/usePostMukburim.ts
+++ b/omechu-app/src/entities/mukburim/model/usePostMukburim.ts
@@ -13,6 +13,7 @@ export function usePostMukburim() {
     onSuccess: (data, menu_name) => {
       // 관련된 쿼리만 새로고침! (예시로 "mukburim" 지정)
       queryClient.invalidateQueries({ queryKey: ["mukburim"] });
+      queryClient.invalidateQueries({ queryKey: ["mukburim-statistics"] });
     },
   });
 }

--- a/omechu-app/src/entities/mukburim/model/usePostMukburim.ts
+++ b/omechu-app/src/entities/mukburim/model/usePostMukburim.ts
@@ -1,7 +1,9 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { mukburimResponse } from "@/entities/mukburim/config/mukburim";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { postMukburim } from "@/entities/mukburim/api/postMukburim";
+import { mukburimResponse } from "@/entities/mukburim/config/mukburim";
 
 export function usePostMukburim() {
   const queryClient = useQueryClient();


### PR DESCRIPTION
---

## PR 설명

먹부림 기록 관련 기능을 개선합니다.

- [x] 추천 목록 페이지 FAB 스크롤 기반 표시/숨김 및 Toast 피드백 추가
- [x] 먹부림 기록 sessionStorage 중복 방지 로직 제거 (같은 메뉴 반복 선택 시 매번 count 누적)
- [x] 먹부림 등록 시 통계 쿼리(mukburim-statistics) 무효화 추가
- [x] usePostMukburim import 순서 정렬

---

## 변경 유형

- [x] 새로운 기능 (feat)
- [x] 리팩토링 (refactor)
- [x] 스타일/디자인 변경 (style/design)

---

## 스크린샷

UI 변경이 있을 경우 스크린샷을 첨부해주세요.

---

## FSD Architecture Checklist

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 추가 설명

- 기존에는 sessionStorage로 동일 세션 내 같은 메뉴의 중복 호출을 막았으나, 같은 메뉴를 여러 번 선택해도 매번 count가 누적되어야 하므로 해당 로직을 제거했습니다.
- cleanQuery를 onSettled 콜백으로 이동하여 race condition을 방지합니다.