### PR TITLE
[FIX] 네이버 인덱싱을 위한 루트 리다이렉트/사이트맵 정리

### DIFF
--- a/omechu-app/next.config.ts
+++ b/omechu-app/next.config.ts
@@ -3,6 +3,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/mainpage",
+        permanent: true,
+      },
+    ];
+  },
   /* config options here */
   images: {
     remotePatterns: [

--- a/omechu-app/src/app/sitemap.ts
+++ b/omechu-app/src/app/sitemap.ts
@@ -5,31 +5,25 @@ import { BASE_URL } from "@/shared/constants/url";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: BASE_URL,
+      url: `${BASE_URL}/mainpage`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,
     },
     {
-      url: `${BASE_URL}/login`,
+      url: `${BASE_URL}/mainpage/result`,
       lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
+      changeFrequency: "daily",
+      priority: 0.9,
     },
     {
-      url: `${BASE_URL}/signup`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${BASE_URL}/fullmenu`,
+      url: `${BASE_URL}/random-recommend`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,
     },
     {
-      url: `${BASE_URL}/restaurant`,
+      url: `${BASE_URL}/menu-battle`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,


### PR DESCRIPTION
- Closes #369

---

## 📌 PR 설명

이번 PR에서 어떤 작업을 했는지 요약해주세요.

- [x] `next.config.ts`에 `/ -> /mainpage` 영구 리다이렉트(308) 규칙 추가
- [x] `sitemap.ts`에서 404 경로(`/fullmenu`, `/restaurant`) 제거 및 실제 공개 경로 반영
- [x] 로컬 프로덕션 실행 기준으로 루트 308, sitemap 200 응답 확인

---

## 🏷 변경 유형

- [ ] 새로운 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일/디자인 변경 (style/design)
- [ ] 문서 수정 (docs)
- [ ] 빌드/CI 설정 (build/ci)
- [ ] 기타 (chore)

---

## 📷 스크린샷

UI 변경 없음

---

## ✅ FSD Architecture Checklist

Feature-Sliced Design 원칙을 준수했는지 확인해주세요.

### 레이어 규칙

- [x] 상위 레이어가 하위 레이어만 import 하고 있음 (app → widgets → entities → shared)
- [x] 동일 레이어 간 import가 없음
- [x] 순환 의존성이 없음

### 네이밍 컨벤션

- [x] 파일명이 정해진 패턴을 따름 (*.tsx, *.hook.ts, *.api.ts 등)
- [x] 폴더명이 kebab-case로 작성됨
- [x] 배럴 익스포트(index.ts)를 사용함

### Import 경로

- [x] 절대 경로 사용 (@/shared, @/entities, @/widgets, @/app)
- [x] 상대 경로 사용 최소화

---

## 🔍 추가 설명

- `pnpm lint`: 기존 경고 44건(이번 변경과 무관) 유지, 에러 없음
- `pnpm build`: 성공
- `pnpm start` + `curl -I /`: `308 Permanent Redirect` 확인